### PR TITLE
Silently ignore charset escapes

### DIFF
--- a/fixtures/rustfmt.sh.raw
+++ b/fixtures/rustfmt.sh.raw
@@ -1,0 +1,7 @@
+Diff in /Users/ryan/Code/arret/compiler/hir/loader.rs at line 1:
+[31m- use std::collections::HashMap;
+(B[m[32m+
+(B[m[32m+use std::collections::HashMap;
+(B[m use std::path;
+ 
+ use crate::hir::error::{Error, ErrorKind, Result};

--- a/fixtures/rustfmt.sh.rendered
+++ b/fixtures/rustfmt.sh.rendered
@@ -1,0 +1,7 @@
+Diff in &#47;Users&#47;ryan&#47;Code&#47;arret&#47;compiler&#47;hir&#47;loader.rs at line 1:
+<span class="term-fg31">- use std::collections::HashMap;</span>
+<span class="term-fg32">+</span>
+<span class="term-fg32">+use std::collections::HashMap;</span>
+ use std::path;
+&nbsp;
+ use crate::hir::error::{Error, ErrorKind, Result};

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -15,6 +15,7 @@ var TestFiles = []string{
 	"npm.sh",
 	"docker-pull.sh",
 	"weather.sh",
+	"rustfmt.sh",
 }
 
 func loadFixture(t testing.TB, base string, ext string) []byte {
@@ -234,6 +235,14 @@ var rendererTestCases = []struct {
 		`uses URL as link content if missing`,
 		"\x1b]1339;url=http://google.com\a",
 		`<a href="http://google.com">http://google.com</a>`,
+	}, {
+		`ignores \x1b(B to set the ASCII charset`,
+		"Hello \x1b(Bworld",
+		`Hello world`,
+	}, {
+		`silently ignores unknown charsets`,
+		"Hello \x1b)2world",
+		`Hello world`,
 	},
 }
 


### PR DESCRIPTION
Rust tools such as Cargo and `rustfmt` seem to like resetting the charset to US ASCII by using `ESC(B` in the middle of a line. Currently this outputs a literal `(B` in the rendered HTML which makes the output look broken.

This simply discards the next character after any `ESC(` or `ESC)`. Initially I only discarded `B` for US ASCII and let the other charsets through as their original escape sequence. However, the existing pattern in the code is to ignore any well-formed escape sequences even if their exact content isn't understood.