### PR TITLE
add backtick html code

### DIFF
--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -53,6 +53,7 @@ func wrapPreview(s []byte) []byte {
 		s = bytes.Replace([]byte(PreviewTemplate), []byte("CONTENT"), s, 1)
 		s = bytes.Replace(s, []byte("STYLESHEET"), MustAsset("assets/terminal.css"), 1)
 	}
+	s = bytes.Replace(s, []byte("`"), []byte("&#96;"), -1)
 	return s
 }
 


### PR DESCRIPTION
We've had issues using `terminal-to-html` with buildkite annotations when there are backticks, which seems to conflict with CommonMark. Using the HTML encoding `&#96;` ensures that backticks won't be parsed as MarkDown.