### PR TITLE
Handles <ESC>[J and <ESC>M

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -168,7 +168,7 @@ func (p *parser) handleControlSequence(char rune) {
 	case ';':
 		p.addInstruction()
 		p.instructionStartedAt = p.cursor + utf8.RuneLen(';')
-	case 'Q', 'K', 'G', 'A', 'B', 'C', 'D', 'M':
+	case 'Q', 'J', 'K', 'G', 'A', 'B', 'C', 'D', 'M':
 		p.addInstruction()
 		p.screen.applyEscape(char, p.instructions)
 		p.mode = MODE_NORMAL

--- a/parser.go
+++ b/parser.go
@@ -213,6 +213,9 @@ func (p *parser) handleEscape(char rune) {
 	case '_':
 		p.instructionStartedAt = p.cursor + utf8.RuneLen('[')
 		p.mode = MODE_APC
+	case 'M':
+		p.screen.revNewLine()
+		p.mode = MODE_NORMAL
 	default:
 		// Not an escape code, false alarm
 		p.cursor = p.escapeStartedAt

--- a/screen.go
+++ b/screen.go
@@ -133,6 +133,15 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 		s.color(instructions)
 	case 'G':
 		s.x = 0
+	case 'J':
+		switch instructions[0] {
+			case "", "0":
+				for i := s.y; i	< len(s.screen); i++ {
+					s.clear(i, screenStartOfLine, screenEndOfLine)
+				}
+			case "2", "3":
+				s.screen = nil
+		}
 	case 'K':
 		switch instructions[0] {
 		case "0", "":

--- a/screen.go
+++ b/screen.go
@@ -133,12 +133,20 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 		s.color(instructions)
 	case 'G':
 		s.x = 0
+	// "Erase in Display"
 	case 'J':
 		switch instructions[0] {
 			case "", "0":
 				for i := s.y; i	< len(s.screen); i++ {
 					s.clear(i, screenStartOfLine, screenEndOfLine)
 				}
+			case "1":
+				// This line should be equivalent to K1
+				s.clear(s.y, screenStartOfLine, s.x)
+				// Truncate the screen above the current line
+				s.screen = s.screen[s.y+1:]
+				// Adjust the cursor position to compensate
+				s.y = 0
 			// 2: "erase entire display", 3: "erase whole display including scroll-back buffer"
 			// Given we don't have a scrollback of our own, we treat these as equivalent
 			case "2", "3":
@@ -146,6 +154,7 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 				s.x = 0
 				s.y = 0
 		}
+	// "Erase in Line"
 	case 'K':
 		switch instructions[0] {
 		case "0", "":

--- a/screen.go
+++ b/screen.go
@@ -184,6 +184,12 @@ func (s *screen) newLine() {
 	s.y++
 }
 
+func (s *screen) revNewLine() {
+	if s.y > 0 {
+		s.y--
+	}
+}
+
 func (s *screen) carriageReturn() {
 	s.x = 0
 }

--- a/screen.go
+++ b/screen.go
@@ -139,8 +139,12 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 				for i := s.y; i	< len(s.screen); i++ {
 					s.clear(i, screenStartOfLine, screenEndOfLine)
 				}
+			// 2: "erase entire display", 3: "erase whole display including scroll-back buffer"
+			// Given we don't have a scrollback of our own, we treat these as equivalent
 			case "2", "3":
 				s.screen = nil
+				s.x = 0
+				s.y = 0
 		}
 	case 'K':
 		switch instructions[0] {

--- a/screen.go
+++ b/screen.go
@@ -136,10 +136,13 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 	// "Erase in Display"
 	case 'J':
 		switch instructions[0] {
-			case "", "0":
-				for i := s.y; i	< len(s.screen); i++ {
-					s.clear(i, screenStartOfLine, screenEndOfLine)
-				}
+			// "erase from current position to end (inclusive)"
+			case "0", "":
+				// This line should be equivalent to K0
+				s.clear(s.y, s.x, screenEndOfLine)
+				// Truncate the screen below the current line
+				s.screen = s.screen[:s.y+1]
+			// "erase from beginning to current position (inclusive)"
 			case "1":
 				// This line should be equivalent to K1
 				s.clear(s.y, screenStartOfLine, s.x)

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -128,6 +128,22 @@ var rendererTestCases = []struct {
 		"\x1b[33mhello\x1b[0m\x1b[33m\x1b[44m\x1b[0Ggoodbye",
 		"<span class=\"term-fg33 term-bg44\">goodbye</span>",
 	}, {
+		`allows clearing lines below the current line`,
+		"foo\nbar\x1b[A\x1b[Jbaz",
+		"foobaz",
+	}, {
+		`allows clearing lines above the current line`,
+		"foo\nbar\x1b[A\x1b[1Jbaz",
+		"barbaz",
+	}, {
+		`allows clearing the entire scrollback buffer with escape 2J`,
+		"this is a big long bit of terminal output\nplease pay it no mind, we will clear it soon\nokay, get ready for a disappearing act...\nand...and...\n\n\x1b[2Jhey presto",
+		"hey presto",
+	}, {
+		`allows clearing the entire scrollback buffer with escape 3J also`,
+		"this is a big long bit of terminal output\nplease pay it no mind, we will clear it soon\nokay, get ready for a disappearing act...\nand...and...\n\n\x1b[2Jhey presto",
+		"hey presto",
+	}, {
 		`allows erasing the current line up to a point`,
 		"hello friend\x1b[1K!",
 		"            !",
@@ -143,6 +159,10 @@ var rendererTestCases = []struct {
 		`\x1b[K correctly clears all previous parts of the string`,
 		"remote: Compressing objects:   0% (1/3342)\x1b[K\rremote: Compressing objects:   1% (34/3342)",
 		"remote: Compressing objects:   1% (34&#47;3342)",
+	}, {
+		`handles reverse linefeed`,
+		"meow\npurr\nnyan\x1bMrawr",
+		"meow\npurrrawr\nnyan",
 	}, {
 		`collapses many spans of the same color into 1`,
 		"\x1b[90m․\x1b[90m․\x1b[90m․\x1b[90m․\n\x1b[90m․\x1b[90m․\x1b[90m․\x1b[90m․",


### PR DESCRIPTION
Clears lines below current line on <ESC>[J, clears entire scrollback buffer on <ESC>[2J or <ESC>[3J.
Also includes support for <ESC>M, reverse linefeed, which is used alongside <ESC>[J in zsh.

Fixes #2