### PR TITLE
Fix go get - github profile name changed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/buildkite/terminal-to-html
 
 go 1.12
 
-require github.com/codegangsta/cli v1.5.0
+require github.com/urfave/cli v1.5.0


### PR DESCRIPTION
Since the developer of the only dependency changed his Github profile name, the `go get` does not work any more:

```
$ go get github.com/buildkite/terminal-to-html/cmd/terminal-to-html
go: github.com/buildkite/terminal-to-html/cmd/terminal-to-html imports
        github.com/codegangsta/cli: github.com/codegangsta/cli@v1.22.2: parsing go.mod:
        module declares its path as: github.com/urfave/cli
                but was required as: github.com/codegangsta/cli
```

This PR fixes this