### PR TITLE
Add meta charset to preview template

### DIFF
--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -33,6 +33,7 @@ var PreviewTemplate = `
 	<!DOCTYPE html>
 	<html>
 		<head>
+			<meta charset="UTF-8">
 			<title>terminal-to-html Preview</title>
 			<style>STYLESHEET</style>
 		</head>


### PR DESCRIPTION
Hello,

I noticed that the preview template is missing a meta tag to define the page encoding.

Without this, the browser can't process the page in the correct encoding.

By adding the line `<meta charset="UTF-8">` to the HTML head section, it can tell the browser this page is using UTF-8 the encoding so browser can't mess it up.

Regards,
imlonghao