### PR TITLE
Bump urfave/cli dependency to the latest 1.x release

### DIFF
--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/buildkite/terminal-to-html"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var AppHelpTemplate = `{{.Name}} - {{.Usage}}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/buildkite/terminal-to-html
 
 go 1.12
 
-require github.com/codegangsta/cli v1.5.0
+require github.com/urfave/cli v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/buildkite/terminal-to-html
 
 go 1.12
 
-require github.com/urfave/cli v1.5.0
+require github.com/urfave/cli v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
-github.com/codegangsta/cli v1.5.0 h1:w1bfQMOiFwLnWC69joajrn5fuwfrtxtJiFMscj2zOWY=
-github.com/codegangsta/cli v1.5.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
+github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Historically, we depended on `github.com/codegangsta/cli` to build our CLI interface. However, the github user has changed their username, so the module import path is now `github.com/urfave/cli`. While updating that, I've bumped us to the latest 1.x version.

There is a fairly recent 2.x release with some breaking changes, but I've held off on that because I haven't wrapped my head around the changes yet.

Note that this includes  PR #69.