### PR TITLE
Attempt to fix go get errors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ You can use the provided `link.sh` to produce this escape sequence.
 If you have Go installed you can simply run the following command to install the `terminal-to-html` command into `$GOPATH/bin`:
 
 ```bash
-$ go get github.com/buildkite/terminal-to-html/cmd/terminal-to-html
+$ GO111MODULE=on go get github.com/buildkite/terminal-to-html/v3/cmd/terminal-to-html
 ```
 
 You can also just download the standalone binary from [https://github.com/buildkite/terminal-to-html/releases](https://github.com/buildkite/terminal-to-html/releases)

--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/buildkite/terminal-to-html"
+	"github.com/buildkite/terminal-to-html/v3"
 	"github.com/urfave/cli"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/buildkite/terminal-to-html
 
 go 1.12
 
-require github.com/urfave/cli v1.22.2
+require github.com/urfave/cli v1.22.4

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/buildkite/terminal-to-html
+module github.com/buildkite/terminal-to-html/v3
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/terminal.go
+++ b/terminal.go
@@ -6,7 +6,7 @@ https://raw.githubusercontent.com/buildkite/terminal-to-html/master/assets/termi
 and wrapped in a term-container div.
 
 You can call this library from the command line with terminal-to-html:
-go install github.com/buildkite/terminal-to-html/cmd/terminal-to-html
+GO111MODULE=on go install github.com/buildkite/terminal-to-html/v3/cmd/terminal-to-html
 */
 package terminal
 


### PR DESCRIPTION
This is an attempt to fix #71 and #74 via copying the approach from buildkite/agent#1115 and notes from buildkite/agent#1026.

As an aside, it attempts to bump urfave/cli to the latest v1 for good measure.

I’m not actually sure how to test that this fixes the problem, given go get wants to download from the specified git URI, and when it’s already locally cached it doesn’t seem to do anything (even with `-v` specified). Tips would be highly welcomed!