### PR TITLE
Updates Dockerfile to to golang 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.2
+FROM golang:1.12
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ RUN apt-get update -q && apt-get install -y zip ruby ruby-dev rpm locales && \
 WORKDIR /go/src/github.com/buildkite/terminal-to-html
 ADD . /go/src/github.com/buildkite/terminal-to-html
 
-CMD [ "make", "dist"]
+ENV GO111MODULE=on
+
+CMD [ "make", "dist" ]


### PR DESCRIPTION
In the process of testing #68, I was unable to build the code in a Go 1.9 docker image. I was able to build after updating the Go image version to 1.12 in the Dockerfile and adding GO111MODULE=on as an environment variable.

This PR changes the Go image version to 1.12 and adds `GO111MODULE=on` to the environment variables. This fixes #80.

It may be worth noting that I was using podman instead of docker, however I don't think that would cause this issue.