### PR TITLE
temporarily disable the deploy steps in our pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,16 +20,16 @@ steps:
       docker-compose#v1.7.0:
         run: terminal
 
-  - block: ":rocket: Release"
+  #- block: ":rocket: Release"
 
-  - name: ":octocat:"
-    command: .buildkite/steps/release
-    branches: "master"
-    agents:
-      queue: "deploy"
+  #- name: ":octocat:"
+  #  command: .buildkite/steps/release
+  #  branches: "master"
+  #  agents:
+  #    queue: "deploy"
 
-  - name: ":packagecloud:"
-    command: .buildkite/steps/package_and_upload
-    branches: "master"
-    agents:
-      queue: "deploy"
+  #- name: ":packagecloud:"
+  #  command: .buildkite/steps/package_and_upload
+  #  branches: "master"
+  #  agents:
+  #    queue: "deploy"


### PR DESCRIPTION
I'm setting this repo up to run CI in a new pipeline where there's no deploy queue available yet.