### PR TITLE
bump version to 3.4.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.3.0"
+var baseVersion string = "3.4.0"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
Oops. This should've been included in the v3.4.0 tag but I wasn't very familiar with this repo at the time I cut the tag.