### PR TITLE
Replace 32-bit Mac builds with arm64 Mac builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.16beta1
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ version:
 
 # Cross-compiling
 
-GZ_ARCH     := linux-amd64 linux-i386 linux-armel darwin-i386 darwin-amd64
+GZ_ARCH     := linux-amd64 linux-i386 linux-armel darwin-amd64 darwin-arm64
 ZIP_ARCH    := windows-i386 windows-amd64
 GZ_TARGETS  := $(foreach target,$(GZ_ARCH), dist/$(BINARY)-$(VERSION)-$(target).gz)
 ZIP_TARGETS := $(foreach target,$(ZIP_ARCH), dist/$(BINARY)-$(VERSION)-$(target).zip)


### PR DESCRIPTION
32-bit software has been unsupported on Macs for two years now, and we've stopped supplying these builds for buildkite-agent already.