### PR TITLE
Fix two classes of overflows possible when clearing portions of screen

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -141,21 +141,17 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 				// This line should be equivalent to K0
 				s.clear(s.y, s.x, screenEndOfLine)
 				// Truncate the screen below the current line
-				thisLineOrEndOfScreen := len(s.screen)
-				if s.y+1 <= thisLineOrEndOfScreen {
-					thisLineOrEndOfScreen = s.y+1
+				if len(s.screen) > s.y {
+					s.screen = s.screen[:s.y+1]
 				}
-				s.screen = s.screen[:thisLineOrEndOfScreen]
 			// "erase from beginning to current position (inclusive)"
 			case "1":
 				// This line should be equivalent to K1
 				s.clear(s.y, screenStartOfLine, s.x)
 				// Truncate the screen above the current line
-				thisLineOrEndOfScreen := len(s.screen)
-				if s.y+1 <= thisLineOrEndOfScreen {
-					thisLineOrEndOfScreen = s.y+1
+				if len(s.screen) > s.y {
+					s.screen = s.screen[s.y+1:]
 				}
-				s.screen = s.screen[thisLineOrEndOfScreen:]
 				// Adjust the cursor position to compensate
 				s.y = 0
 			// 2: "erase entire display", 3: "erase whole display including scroll-back buffer"

--- a/screen.go
+++ b/screen.go
@@ -141,13 +141,21 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 				// This line should be equivalent to K0
 				s.clear(s.y, s.x, screenEndOfLine)
 				// Truncate the screen below the current line
-				s.screen = s.screen[:s.y+1]
+				thisLineOrEndOfScreen := len(s.screen)
+				if s.y+1 <= thisLineOrEndOfScreen {
+					thisLineOrEndOfScreen = s.y+1
+				}
+				s.screen = s.screen[:thisLineOrEndOfScreen]
 			// "erase from beginning to current position (inclusive)"
 			case "1":
 				// This line should be equivalent to K1
 				s.clear(s.y, screenStartOfLine, s.x)
 				// Truncate the screen above the current line
-				s.screen = s.screen[s.y+1:]
+				thisLineOrEndOfScreen := len(s.screen)
+				if s.y+1 <= thisLineOrEndOfScreen {
+					thisLineOrEndOfScreen = s.y+1
+				}
+				s.screen = s.screen[thisLineOrEndOfScreen:]
 				// Adjust the cursor position to compensate
 				s.y = 0
 			// 2: "erase entire display", 3: "erase whole display including scroll-back buffer"

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -132,9 +132,17 @@ var rendererTestCases = []struct {
 		"foo\nbar\x1b[A\x1b[Jbaz",
 		"foobaz",
 	}, {
+		`doesn't freak out about clearing lines below when there aren't any`,
+		"foobar\x1b[0J",
+		"foobar",
+	}, {
 		`allows clearing lines above the current line`,
 		"foo\nbar\x1b[A\x1b[1Jbaz",
 		"barbaz",
+	}, {
+		`doesn't freak out about clearing lines above when there aren't any`,
+		"\x1b[1Jfoobar",
+		"foobar",
 	}, {
 		`allows clearing the entire scrollback buffer with escape 2J`,
 		"this is a big long bit of terminal output\nplease pay it no mind, we will clear it soon\nokay, get ready for a disappearing act...\nand...and...\n\n\x1b[2Jhey presto",


### PR DESCRIPTION
An issue introduced by an oversight in #68, it was possible for the line clearing instructions to fail if there weren't any lines present to clear in their respective positions.