### PR TITLE
Buildkite timestamps are zero-width via persistent elements

### DIFF
--- a/node.go
+++ b/node.go
@@ -13,8 +13,25 @@ func (n *node) hasSameStyle(o node) bool {
 }
 
 func (n *node) getRune() (rune, bool) {
-	if n.elem != nil {
-		return 0, false
+	// ELEMENT_BK are special zero-width elements that piggy-back onto other nodes.
+	// If the node they're attached to has a non-zero-value blob (rune) then that should
+	// also be rendered.
+	// This means if an ELEMENT_BK is immediately followed by a null/zero byte,
+	// that null/zero byte will not be rendered. This is not ideal, and the
+	// whole ELEMENT_BK/timestamp subsystem needs an overhaul, but it's
+	// probably fine in practice; timestamps should be at the start of lines,
+	// null bytes shouldn't. And there's probably no useful/valid way to render
+	// them anyway.
+	if n.elem == nil || (n.elem.elementType == ELEMENT_BK && n.blob != 0) {
+		return n.blob, true
 	}
-	return n.blob, true
+	return 0, false
+}
+
+// Whether the node has an element that persists when the node is overwritten.
+// e.g. _bk;t=... timestamps are zero-width, placed in the _next_ node to be written.
+// (That's _usually_ the start of a line, but not necessarily)
+// The subsequent write to that next node needs to retain the element.
+func (n *node) hasPersistentElement() bool {
+	return n.elem != nil && n.elem.elementType == ELEMENT_BK
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -29,7 +29,6 @@ func TestParseAfterOverwriteAndClearToEndOfLine(t *testing.T) {
 // Application Program Command should be zero-width
 func TestParseZeroWidthAPC(t *testing.T) {
 	s := parsedScreen("\x1b_bk;t=0\x07")
-	t.Skip("zero-width _bk;t=... bug")
 	if err := assertTextXY(t, s, "", 0, 0); err != nil {
 		t.Error(err)
 	}
@@ -38,7 +37,6 @@ func TestParseZeroWidthAPC(t *testing.T) {
 // Application Program Command can be followed by normal text
 func TestParseAPCPrefix(t *testing.T) {
 	s := parsedScreen("\x1b_bk;t=0\x07hello")
-	t.Skip("zero-width _bk;t=... bug")
 	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
@@ -47,7 +45,6 @@ func TestParseAPCPrefix(t *testing.T) {
 // Application Program Command should be zero-width for cursor movement
 func TestParseXYAfterCursorMovementThroughBuildkiteTimestampAPC(t *testing.T) {
 	s := parsedScreen("hel\x1b_bk;t=0\x07lo\x1b[4D3")
-	t.Skip("zero-width _bk;t=... bug")
 	if err := assertTextXY(t, s, "h3llo", 2, 0); err != nil {
 		t.Error(err)
 	}

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -284,9 +284,9 @@ var rendererTestCases = []struct {
 		"Buildbox\x1b[3Dkite", // Buildbox{CUBx3}kite
 		`Buildkite`,
 	}, {
-		`handles _bk timestamps as zero-width for cursor movement`,
-		"Buildb\x1b_bk;t=0\x07ox\x1b[3Dkite", // Buildb{TS}ox{CUBx3}kite
-		`Buildkite`,
+		`handles _bk timestmaps as zero-width for cursor movement`,
+		"Buildb\x1b_bk;t=123\x07ox\x1b[3Dkite", // Buildb{TS}ox{CUBx3}kite
+		`Buildk<?bk t="123"?>ite`,
 	},
 }
 

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -279,6 +279,14 @@ var rendererTestCases = []struct {
 		`renders bk APC escapes surrounded by text`,
 		"hello \x1b_bk;t=123\x07 world",
 		`hello <?bk t="123"?> world`,
+	}, {
+		`handles cursor movement and overwrite`,
+		"Buildbox\x1b[3Dkite", // Buildbox{CUBx3}kite
+		`Buildkite`,
+	}, {
+		`handles _bk timestamps as zero-width for cursor movement`,
+		"Buildb\x1b_bk;t=0\x07ox\x1b[3Dkite", // Buildb{TS}ox{CUBx3}kite
+		`Buildkite`,
 	},
 }
 


### PR DESCRIPTION
As reported in #96, Buildkite's timestamping ANSI Application Program Command is interfering with cursor movements.

For example a 10-character-wide progress bars might move the cursor back 10 characters to overwrite itself with an update. An invisible timestamp within the progress bar would erroneously consume on of the cursor movements, making it move only 9 characters, leaving a stray character on the left, and accumulating as this repeats.

- [x] Reproduce in a test case.
- [x] Fix.

Closes #96