### PR TITLE
Refactor before fixing zero-width bk APC timestamps

### DIFF
--- a/element.go
+++ b/element.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"mime"
-	"strings"
 	"sort"
+	"strings"
 )
 
 const (

--- a/node.go
+++ b/node.go
@@ -11,3 +11,10 @@ type node struct {
 func (n *node) hasSameStyle(o node) bool {
 	return n.style.isEqual(o.style)
 }
+
+func (n *node) getRune() (rune, bool) {
+	if n.elem != nil {
+		return 0, false
+	}
+	return n.blob, true
+}

--- a/output.go
+++ b/output.go
@@ -65,10 +65,13 @@ func outputLineAsHTML(line []node) string {
 				}
 			}
 		}
-		if node.elem != nil {
-			lineBuf.buf.WriteString(node.elem.asHTML())
-		} else {
-			lineBuf.appendChar(node.blob)
+
+		if elem := node.elem; elem != nil {
+			lineBuf.buf.WriteString(elem.asHTML())
+		}
+
+		if r, ok := node.getRune(); ok {
+			lineBuf.appendChar(r)
 		}
 	}
 	if spanOpen {

--- a/parser.go
+++ b/parser.go
@@ -144,7 +144,7 @@ func (p *parser) handleApplicationProgramCommand(char rune) {
 	}
 	p.mode = MODE_NORMAL
 
-	// Bell received, stop parsing our potential image
+	// this might be a Buildkite Application Program Command sequence...
 	el, err := parseBuildkiteElementSequence(string(p.ansi[p.instructionStartedAt:p.cursor]))
 
 	if el == nil && err == nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,89 @@
+package terminal
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseSimpleXY(t *testing.T) {
+	s := parsedScreen("hello")
+	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestParseAfterCursorMovement(t *testing.T) {
+	s := parsedScreen("hello\x1b[4D!")
+	if err := assertTextXY(t, s, "h!llo", 2, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestParseAfterOverwriteAndClearToEndOfLine(t *testing.T) {
+	s := parsedScreen("hello\x1b[4Di!\x1b[0K")
+	if err := assertTextXY(t, s, "hi!", 3, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+// Application Program Command should be zero-width
+func TestParseZeroWidthAPC(t *testing.T) {
+	s := parsedScreen("\x1b_bk;t=0\x07")
+	t.Skip("zero-width _bk;t=... bug")
+	if err := assertTextXY(t, s, "", 0, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+// Application Program Command can be followed by normal text
+func TestParseAPCPrefix(t *testing.T) {
+	s := parsedScreen("\x1b_bk;t=0\x07hello")
+	t.Skip("zero-width _bk;t=... bug")
+	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+// Application Program Command should be zero-width for cursor movement
+func TestParseXYAfterCursorMovementThroughBuildkiteTimestampAPC(t *testing.T) {
+	s := parsedScreen("hel\x1b_bk;t=0\x07lo\x1b[4D3")
+	t.Skip("zero-width _bk;t=... bug")
+	if err := assertTextXY(t, s, "h3llo", 2, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+// ----------------------------------------
+
+func parsedScreen(data string) *screen {
+	s := &screen{}
+	parseANSIToScreen(s, []byte(data))
+	return s
+}
+
+func assertXY(t *testing.T, s *screen, x, y int) error {
+	if s.x != x {
+		return fmt.Errorf("expected screen.x == %d, got %d", x, s.x)
+	}
+	if s.y != y {
+		return fmt.Errorf("expected screen.y == %d, got %d", y, s.y)
+	}
+	return nil
+}
+
+func assertText(t *testing.T, s *screen, expected string) error {
+	if actual := s.asPlainText(); actual != expected {
+		return fmt.Errorf("expected text %q, got %q", expected, actual)
+	}
+	return nil
+}
+
+func assertTextXY(t *testing.T, s *screen, expected string, x, y int) error {
+	if err := assertXY(t, s, x, y); err != nil {
+		return err
+	}
+	if err := assertText(t, s, expected); err != nil {
+		return err
+	}
+	return nil
+}

--- a/screen.go
+++ b/screen.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"bytes"
 	"math"
 	"strconv"
 	"strings"
@@ -197,6 +198,22 @@ func (s *screen) asHTML() []byte {
 	}
 
 	return []byte(strings.Join(lines, "\n"))
+}
+
+// asPlainText renders the screen without any ANSI style etc.
+func (s *screen) asPlainText() string {
+	var buf bytes.Buffer
+	for i, line := range s.screen {
+		for _, node := range line {
+			if node.elem == nil {
+				buf.WriteRune(node.blob)
+			}
+		}
+		if i < len(s.screen)-1 {
+			buf.WriteRune('\n')
+		}
+	}
+	return strings.TrimRight(buf.String(), " \t")
 }
 
 func (s *screen) newLine() {

--- a/screen.go
+++ b/screen.go
@@ -136,30 +136,30 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 	// "Erase in Display"
 	case 'J':
 		switch instructions[0] {
-			// "erase from current position to end (inclusive)"
-			case "0", "":
-				// This line should be equivalent to K0
-				s.clear(s.y, s.x, screenEndOfLine)
-				// Truncate the screen below the current line
-				if len(s.screen) > s.y {
-					s.screen = s.screen[:s.y+1]
-				}
-			// "erase from beginning to current position (inclusive)"
-			case "1":
-				// This line should be equivalent to K1
-				s.clear(s.y, screenStartOfLine, s.x)
-				// Truncate the screen above the current line
-				if len(s.screen) > s.y {
-					s.screen = s.screen[s.y+1:]
-				}
-				// Adjust the cursor position to compensate
-				s.y = 0
-			// 2: "erase entire display", 3: "erase whole display including scroll-back buffer"
-			// Given we don't have a scrollback of our own, we treat these as equivalent
-			case "2", "3":
-				s.screen = nil
-				s.x = 0
-				s.y = 0
+		// "erase from current position to end (inclusive)"
+		case "0", "":
+			// This line should be equivalent to K0
+			s.clear(s.y, s.x, screenEndOfLine)
+			// Truncate the screen below the current line
+			if len(s.screen) > s.y {
+				s.screen = s.screen[:s.y+1]
+			}
+		// "erase from beginning to current position (inclusive)"
+		case "1":
+			// This line should be equivalent to K1
+			s.clear(s.y, screenStartOfLine, s.x)
+			// Truncate the screen above the current line
+			if len(s.screen) > s.y {
+				s.screen = s.screen[s.y+1:]
+			}
+			// Adjust the cursor position to compensate
+			s.y = 0
+		// 2: "erase entire display", 3: "erase whole display including scroll-back buffer"
+		// Given we don't have a scrollback of our own, we treat these as equivalent
+		case "2", "3":
+			s.screen = nil
+			s.x = 0
+			s.y = 0
 		}
 	// "Erase in Line"
 	case 'K':

--- a/screen.go
+++ b/screen.go
@@ -38,7 +38,7 @@ func (s *screen) clear(y int, xStart int, xEnd int) {
 }
 
 // "Safe" parseint for parsing ANSI instructions
-func pi(s string) int {
+func ansiInt(s string) int {
 	if s == "" {
 		return 1
 	}
@@ -48,23 +48,23 @@ func pi(s string) int {
 
 // Move the cursor up, if we can
 func (s *screen) up(i string) {
-	s.y -= pi(i)
+	s.y -= ansiInt(i)
 	s.y = int(math.Max(0, float64(s.y)))
 }
 
 // Move the cursor down
 func (s *screen) down(i string) {
-	s.y += pi(i)
+	s.y += ansiInt(i)
 }
 
 // Move the cursor forward on the line
 func (s *screen) forward(i string) {
-	s.x += pi(i)
+	s.x += ansiInt(i)
 }
 
 // Move the cursor backward, if we can
 func (s *screen) backward(i string) {
-	s.x -= pi(i)
+	s.x -= ansiInt(i)
 	s.x = int(math.Max(0, float64(s.x)))
 }
 

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -284,23 +284,27 @@ var rendererTestCases = []struct {
 
 func TestRendererAgainstCases(t *testing.T) {
 	for _, c := range rendererTestCases {
-		output := string(Render([]byte(c.input)))
-		if output != c.expected {
-			t.Errorf("%s\ninput\t\t%q\nreceived\t%q\nexpected\t%q", c.name, c.input, output, c.expected)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			output := string(Render([]byte(c.input)))
+			if output != c.expected {
+				t.Errorf("%s\ninput\t\t%q\nreceived\t%q\nexpected\t%q", c.name, c.input, output, c.expected)
+			}
+		})
 	}
 }
 
 func TestRendererAgainstFixtures(t *testing.T) {
 	for _, base := range TestFiles {
-		raw := loadFixture(t, base, "raw")
-		expected := string(loadFixture(t, base, "rendered"))
+		t.Run(fmt.Sprintf("for fixture %q", base), func(t *testing.T) {
+			raw := loadFixture(t, base, "raw")
+			expected := string(loadFixture(t, base, "rendered"))
 
-		output := string(Render(raw))
+			output := string(Render(raw))
 
-		if output != expected {
-			t.Errorf("%s did not match, got len %d and expected len %d", base, len(output), len(expected))
-		}
+			if output != expected {
+				t.Errorf("%s did not match, got len %d and expected len %d", base, len(output), len(expected))
+			}
+		})
 	}
 }
 

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -268,9 +268,17 @@ var rendererTestCases = []struct {
 		"\x1b]1339;url=http://google.com\a",
 		`<a href="http://google.com">http://google.com</a>`,
 	}, {
-		`renders APC escapes as processing instructions`,
+		`renders bk APC escapes as processing instructions`,
 		"\x1b_bk;x=llamas\\;;y=alpacas\x07",
 		`<?bk x="llamas;" y="alpacas"?>`,
+	}, {
+		`renders bk APC escapes followed by text`,
+		"\x1b_bk;t=123\x07hello",
+		`<?bk t="123"?>hello`,
+	}, {
+		`renders bk APC escapes surrounded by text`,
+		"hello \x1b_bk;t=123\x07 world",
+		`hello <?bk t="123"?> world`,
 	},
 }
 


### PR DESCRIPTION
In #97 I ended up with a bunch of refactoring / testing and a working solution for #96. But I don't like the solution, and want to try a different approach.

So this pull request extracts the refactoring and tests, but doesn't change any behaviour.

The previous and future solution PRs can be rebased onto this to make comparison clearer.