### PR TITLE
Buildkite timestamps only at start of line, via screenLine.metadata

### DIFF
--- a/bk.go
+++ b/bk.go
@@ -1,0 +1,33 @@
+package terminal
+
+import (
+	"fmt"
+	"strings"
+)
+
+const bkNamespace = "bk"
+
+// Parse an Application Program Command sequence, which may or may not be a
+// Buildkite APC, e.g. bk;t=123123234234234;llamas=blah
+func parseApcBk(sequence string) (map[string]string, error) {
+	if !strings.HasPrefix(sequence, bkNamespace+";") {
+		return nil, nil
+	}
+
+	tokens, err := tokenizeString(sequence[3:], ';', '\\')
+	if err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{}
+
+	for _, token := range tokens {
+		tokenParts := strings.SplitN(token, "=", 2)
+		if len(tokenParts) != 2 {
+			return nil, fmt.Errorf("Failed to read key=value from token %q", token)
+		}
+		data[tokenParts[0]] = tokenParts[1]
+	}
+
+	return data, nil
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -29,7 +29,6 @@ func TestParseAfterOverwriteAndClearToEndOfLine(t *testing.T) {
 // Application Program Command should be zero-width
 func TestParseZeroWidthAPC(t *testing.T) {
 	s := parsedScreen("\x1b_bk;t=0\x07")
-	t.Skip("zero-width _bk;t=... bug")
 	if err := assertTextXY(t, s, "", 0, 0); err != nil {
 		t.Error(err)
 	}
@@ -38,7 +37,6 @@ func TestParseZeroWidthAPC(t *testing.T) {
 // Application Program Command can be followed by normal text
 func TestParseAPCPrefix(t *testing.T) {
 	s := parsedScreen("\x1b_bk;t=0\x07hello")
-	t.Skip("zero-width _bk;t=... bug")
 	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
@@ -47,7 +45,6 @@ func TestParseAPCPrefix(t *testing.T) {
 // Application Program Command should be zero-width for cursor movement
 func TestParseXYAfterCursorMovementThroughBuildkiteTimestampAPC(t *testing.T) {
 	s := parsedScreen("hel\x1b_bk;t=0\x07lo\x1b[4D3")
-	t.Skip("zero-width _bk;t=... bug")
 	if err := assertTextXY(t, s, "h3llo", 2, 0); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
As discussed in #96 and #97, Buildkite timestamps (`<ESC>_bk;t=123456<BEL>`) were corrupting virtual terminal X position when moving the cursor backwards through them (“CUB”: `<ESC>[<distance>D`). This is because they occupied a position on the terminal intermediate representation X,Y grid, and parsing/appending them incremented the internal X-position state. Buildkite timestamps should generally only appear at the start of lines, where this isn't a problem, but [certain ANSI sequences cause buildkite/agent to place them mid-line](https://github.com/buildkite/agent/issues/1738).

This pull request introduces a “line metadata” structure, supporting namespaced key:value data attached to entire lines. For example the Buildkite APC `<ESC>_bk;t=1234<BEL>` places `t`→`1234` under the `bk` namespace. Subsequent `_bk;t` APCs on the same line are ignored. The `bk` namespace is then rendered as `<?bk t="1234"?>` prior to the line's terminal data, so it's always at the start of the line.

Some refactoring to achieve that:
- `_bk` data is no longer represented as a subtype of `struct element`, but as `metadata map[string]map[string]string` on a new `struct screenLine` which wraps the bare `[]node` that previously represented a line.
- A new `screen.setnxLineMetadata()` method, with a [Redis-inspired name](https://redis.io/commands/setnx/) indicating that it only sets keys that don't already exist.
- `screen.getCurrentLineForWriting() *screenLine` replaces the previous `growScreenHeight()` and `growLineWidth()` since those were always used in conjunction to prepare for writing data that might be out of existing bounds, and this was also required prior to adding `_bk;t` metadata to a new line.
- rendering `<?bk …?>` to HTML is separated out of the rendering of `struct element` because it's no longer one of those.

This PR is currently based on [some other more minor refactoring](https://github.com/buildkite/terminal-to-html/pull/98) that was extracted from [a previous approach that I don't want to merge](https://github.com/buildkite/terminal-to-html/pull/97).

Related:
- Fixes #96
- Closes #97
- #98
-  buildkite/agent#1738