### PR TITLE
Docker and Makefile uplift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM golang:1.16beta1
+FROM golang:1.19
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
 
-RUN apt-get update -q && apt-get install -y zip ruby ruby-dev rpm locales && \
-  go get github.com/kardianos/govendor && \
-  go get github.com/buildkite/github-release && \
-  gem install --no-ri --no-rdoc rake fpm package_cloud && \
-  echo "en_US UTF-8" > /etc/locale.gen && \
+RUN apt-get update -q && \
+  apt-get install -y zip ruby ruby-dev rpm locales
+
+RUN go install github.com/buildkite/github-release@latest
+
+RUN gem install --no-document rake fpm package_cloud
+
+RUN echo "en_US UTF-8" > /etc/locale.gen && \
   locale-gen en_US.UTF-8
 
 WORKDIR /go/src/github.com/buildkite/terminal-to-html
 ADD . /go/src/github.com/buildkite/terminal-to-html
-
-ENV GO111MODULE=on
 
 CMD [ "make", "dist" ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SRC=*.go cmd/terminal-to-html/*.go
 BINARY=terminal-to-html
-BUILDCMD=go build -o $@ ./cmd/terminal-to-html
+BUILDCMD=go build -trimpath -o $@ ./cmd/terminal-to-html
 VERSION=$(shell cat version.go  | grep baseVersion | head -n1 | cut -d \" -f 2)
 
 all: test $(BINARY)

--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ Links which contain semicolons can be surrounded by either single or double quot
 If you have Go installed you can simply run the following command to install the `terminal-to-html` command into `$GOPATH/bin`:
 
 ```bash
-$ GO111MODULE=on go get github.com/buildkite/terminal-to-html/v3/cmd/terminal-to-html
+$ go install github.com/buildkite/terminal-to-html/v3/cmd/terminal-to-html
 ```
 
 You can also just download the standalone binary from [https://github.com/buildkite/terminal-to-html/releases](https://github.com/buildkite/terminal-to-html/releases)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
-terminal:
-  build: .
-  volumes:
-    - ./:/go/src/github.com/buildkite/terminal-to-html
-  environment:
-    - GITHUB_RELEASE_ACCESS_TOKEN
-    - PACKAGECLOUD_TOKEN
+services:
+
+  terminal:
+    build: .
+    volumes:
+      - ./:/go/src/github.com/buildkite/terminal-to-html
+    environment:
+      - GITHUB_RELEASE_ACCESS_TOKEN
+      - PACKAGECLOUD_TOKEN


### PR DESCRIPTION
Update `Dockerfile` to `golang:1.19`, was `golang:1.16beta1` 😬, and make some other changes to get it building.
Update `docker-compose.yml`; modern `docker-compose` didn't even understand it without a top-level `services:`.
That said, I didn't end up using the docker gear to create the latest [v3.7.0 release](https://github.com/buildkite/terminal-to-html/releases/tag/v3.7.0), so it's possible the docker gear still has problems.

Also, update `Makefile` to pass `-trimpath` to `go build` so that the local directory path of the machine creating the builds isn't included in the binaries.