### PR TITLE
DECSC & DECRC (save/restore cursor position) implemented.

### DIFF
--- a/fixtures/cursor-save-restore.sh.raw
+++ b/fixtures/cursor-save-restore.sh.raw
@@ -1,0 +1,6 @@
+first line
+second line
+third line
+fourth line
+7[3A[2K[1Goverwrite
+8fifth line

--- a/fixtures/cursor-save-restore.sh.rendered
+++ b/fixtures/cursor-save-restore.sh.rendered
@@ -1,0 +1,5 @@
+first line
+overwrite
+third line
+fourth line
+fifth line

--- a/parser.go
+++ b/parser.go
@@ -14,6 +14,10 @@ const (
 	MODE_APC     = iota
 )
 
+type position struct {
+	x, y int
+}
+
 // Stateful ANSI parser
 type parser struct {
 	mode                 int
@@ -23,6 +27,7 @@ type parser struct {
 	escapeStartedAt      int
 	instructions         []string
 	instructionStartedAt int
+	savePosition         position
 }
 
 /*
@@ -232,6 +237,13 @@ func (p *parser) handleEscape(char rune) {
 		p.mode = MODE_APC
 	case 'M':
 		p.screen.revNewLine()
+		p.mode = MODE_NORMAL
+	case '7':
+		p.savePosition = position{x: p.screen.x, y: p.screen.y}
+		p.mode = MODE_NORMAL
+	case '8':
+		p.screen.x = p.savePosition.x
+		p.screen.y = p.savePosition.y
 		p.mode = MODE_NORMAL
 	default:
 		// Not an escape code, false alarm

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -10,12 +10,13 @@ import (
 var TestFiles = []string{
 	"control.sh",
 	"curl.sh",
-	"homer.sh",
-	"pikachu.sh",
-	"npm.sh",
+	"cursor-save-restore.sh",
 	"docker-pull.sh",
-	"weather.sh",
+	"homer.sh",
+	"npm.sh",
+	"pikachu.sh",
 	"rustfmt.sh",
+	"weather.sh",
 }
 
 func loadFixture(t testing.TB, base string, ext string) []byte {


### PR DESCRIPTION
Implement the `DECSC` & `DECRC` (save/restore cursor position) terminal escape sequences. Previously they were ignored.

- `DECSC` ([DEC](https://en.wikipedia.org/wiki/Digital_Equipment_Corporation) Save Cursor) is `ESC 7`, and it saves the current cursor position to memory.
- `DECRC` ([DEC](https://en.wikipedia.org/wiki/Digital_Equipment_Corporation) Restore Cursor) is `ESC 8`, and it restores the saved cursor position by jumping back to that position.

I believe there exists tools/libraries in the private and/or public npm ecosystem that use DECSC/DECRC as part of rewriting earlier lines in a terminal to update their status. This fixes terminal-to-html rendering of those scenarios.

Related:
- https://en.wikipedia.org/wiki/ANSI_escape_code#Fp_Escape_sequences
- https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#simple-cursor-positioning