### PR TITLE
Overwrite line metadata

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -177,9 +177,10 @@ func (p *parser) handleApplicationProgramCommand(char rune) {
 		return
 	}
 
-	if data != nil {
-		p.screen.setnxLineMetadata(bkNamespace, data)
+	if data == nil {
+		return
 	}
+	p.screen.setLineMetadata(bkNamespace, data)
 }
 
 func (p *parser) handleControlSequence(char rune) {

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -305,13 +306,19 @@ var rendererTestCases = []struct {
 		"hello \x1b_bk;t=123\x07world",
 		`<?bk t="123"?>hello world`,
 	}, {
-		`prefixes lines with the first timestamp seen`,
+		`prefixes lines with the last timestamp seen`,
 		"hello\x1b_bk;t=123\x07 world\x1b_bk;t=456\x07!",
-		`<?bk t="123"?>hello world!`,
+		`<?bk t="456"?>hello world!`,
 	}, {
 		`handles timestamps across multiple lines`,
-		"hello\x1b_bk;t=123\x07 world\x1b_bk;t=234\x07!\nanother\x1b_bk;t=345\x07 line\x1b_bk;t=456\x07!",
-		`<?bk t="123"?>hello world!` + "\n" + `<?bk t="345"?>another line!`,
+		strings.Join([]string{
+			"hello\x1b_bk;t=123\x07 world\x1b_bk;t=234\x07!",
+			"another\x1b_bk;t=345\x07 line\x1b_bk;t=456\x07!",
+		}, "\n"),
+		strings.Join([]string{
+			`<?bk t="234"?>hello world!`,
+			`<?bk t="456"?>another line!`,
+		}, "\n"),
 	},
 }
 


### PR DESCRIPTION
What timestamp should a rewritten line have?

I argue we should replace old line metadata with new metadata. This will make timestamps look more sensible in `ESC [1A ESC [K`-heavy output. 

For example, when faced with updating the existing screen (pseudo-rendered):

```
<?bk t="0"?>Commencing build...
<?bk t="1"?>Enumerating packages...
```

with a sequence like `ESC [1A ESC [K ESC _bk;t=200 BEL Completed! LF`, we currently get

```
<?bk t="0"?>Commencing build...
<?bk t="1"?>Completed!
```

which is nonsensical from a timestamp perspective (`Completed!` actually happened at t=200).

The current approach does have a benefit: assuming the timestamps are non-decreasing, it is somewhat possible to derive the "duration" of a line (assuming each line is printed at the very start of a chunk of processing). In the example above, `Commencing build...` can be inferred to take Δt = 1; if `Completed!` has t=200, then `Commencing build...`'s inferred Δt = 200, when 199 of that was actually spent starting with package enumeration. But to do this effectively requires making that assumption.

I also tweaked the style of `setLineMetadata`, and implemented an optimisation for `clear`.