### PR TITLE
Disable cgo on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SRC=*.go cmd/terminal-to-html/*.go
 BINARY=terminal-to-html
-BUILDCMD=go build -trimpath -o $@ ./cmd/terminal-to-html
+BUILDCMD=CGO_ENABLED=0 go build -trimpath -o $@ ./cmd/terminal-to-html
 VERSION=$(shell cat version.go  | grep baseVersion | head -n1 | cut -d \" -f 2)
 
 all: test $(BINARY)


### PR DESCRIPTION
Whenever I build this on my machine, it does not work when we use this
in prod. On of the causes is that my machine has a newer version of glibc than
the one used in prod.

Disabling CGO should fix this.

To check that this does indeed disable CGO, you can run:
```
go tool nm <path-to-binary> | grep Cfunc
```
on the binary that matches the OS and ARCH that the build was run on.

Here's a log from my machine that demonstrates this:
```
terminal-to-html on  main [$] via 🐹 v1.20.6 on ☁️
🕙 16:33:58 ❯ make clean
rm -f terminal-to-html
rm -rf dist bin
terminal-to-html on  main [$] via 🐹 v1.20.6 on ☁️
🕙 16:34:03 ❯ make
go test
PASS
ok  	github.com/buildkite/terminal-to-html/v3	0.024s
go build -trimpath -o terminal-to-html ./cmd/terminal-to-html
terminal-to-html on  main [$] via 🐹 v1.20.6 on ☁️
🕙 16:34:05 ❯ go tool nm ./terminal-to-html | grep Cfunc
  401060 T _cgo_cbcce81e6342_Cfunc_free
  401070 T _cgo_cbcce81e6342_Cfunc_freeaddrinfo
  401080 T _cgo_cbcce81e6342_Cfunc_gai_strerror
  4010b0 T _cgo_cbcce81e6342_Cfunc_getaddrinfo
  5d1fc0 T net._Cfunc_freeaddrinfo.abi0
  5d2040 T net._Cfunc_gai_strerror.abi0
  a8f848 D net._cgo_cbcce81e6342_Cfunc_freeaddrinfo
  a8f850 D net._cgo_cbcce81e6342_Cfunc_gai_strerror
terminal-to-html on  main [$] via 🐹 v1.20.6 on ☁️
🕙 16:34:08 ❯ git switch -
Switched to branch 'pdp-1398-build-terminal-to-html-without-cgo'
terminal-to-html on  pdp-1398-build-terminal-to-html-without-cgo [$] via 🐹 v1.20.6 on ☁️
🕙 16:34:13 ❯ make clean
rm -f terminal-to-html
rm -rf dist bin
terminal-to-html on  pdp-1398-build-terminal-to-html-without-cgo [$] via 🐹 v1.20.6 on ☁️
🕙 16:34:17 ❯ make
go test
PASS
ok  	github.com/buildkite/terminal-to-html/v3	0.027s
CGO_ENABLED=0 go build -trimpath -o terminal-to-html ./cmd/terminal-to-html
terminal-to-html on  pdp-1398-build-terminal-to-html-without-cgo [$] via 🐹 v1.20.6 on ☁️
🕙 16:34:21 ❯ go tool nm ./terminal-to-html | grep Cfunc
terminal-to-html on  pdp-1398-build-terminal-to-html-without-cgo [$] via 🐹 v1.20.6 on ☁️
🕙 16:34:24 ❯ echo $status
1
```