### PR TITLE
Delta timestamping

### DIFF
--- a/bk_test.go
+++ b/bk_test.go
@@ -1,0 +1,60 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseBuildkiteAPC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		parser     *parser
+		sequence   string
+		wantData   map[string]string
+		wantLastTS int64
+	}{
+		{
+			name:       "t field",
+			parser:     &parser{},
+			sequence:   "bk;t=12345",
+			wantData:   map[string]string{"t": "12345"},
+			wantLastTS: 12345,
+		},
+		{
+			name:       "dt becomes t",
+			parser:     &parser{lastTimestamp: 12345},
+			sequence:   "bk;dt=123",
+			wantData:   map[string]string{"t": "12468"},
+			wantLastTS: 12468,
+		},
+		{
+			name:       "other field parsed",
+			parser:     &parser{},
+			sequence:   "bk;t=12345;p=np",
+			wantData:   map[string]string{"t": "12345", "p": "np"},
+			wantLastTS: 12345,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.sequence, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := test.parser.parseBuildkiteAPC(test.sequence)
+			if err != nil {
+				t.Fatalf("parseBuildkiteAPC(%q) error = %v", test.sequence, err)
+			}
+			if diff := cmp.Diff(got, test.wantData); diff != "" {
+				t.Errorf("parsed buildkite APC data diff (-got +want):\n%s", diff)
+			}
+			if got, want := test.parser.lastTimestamp, test.wantLastTS; got != want {
+				t.Errorf("parser.lastTimestamp = %d, want %d", got, want)
+			}
+		})
+
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -28,6 +28,9 @@ type parser struct {
 	instructions         []string
 	instructionStartedAt int
 	savePosition         position
+
+	// Buildkite-specific state
+	lastTimestamp int64
 }
 
 /*
@@ -170,7 +173,7 @@ func (p *parser) handleApplicationProgramCommand(char rune) {
 	sequence := string(p.ansi[p.instructionStartedAt:p.cursor])
 
 	// this might be a Buildkite Application Program Command sequence...
-	data, err := parseApcBk(sequence)
+	data, err := p.parseBuildkiteAPC(sequence)
 	if err != nil {
 		p.screen.appendMany([]rune("*** Error parsing Buildkite APC ANSI escape sequence: "))
 		p.screen.appendMany([]rune(err.Error()))

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -319,6 +319,16 @@ var rendererTestCases = []struct {
 			`<?bk t="234"?>hello world!`,
 			`<?bk t="456"?>another line!`,
 		}, "\n"),
+	}, {
+		`handles timestamps and delta timestamps`,
+		strings.Join([]string{
+			"hello\x1b_bk;t=123\x07 world\x1b_bk;dt=111\x07!",
+			"another\x1b_bk;dt=111\x07 line\x1b_bk;dt=111\x07!",
+		}, "\n"),
+		strings.Join([]string{
+			`<?bk t="234"?>hello world!`,
+			`<?bk t="456"?>another line!`,
+		}, "\n"),
 	},
 }
 


### PR DESCRIPTION
Per-line ("ANSI") timestamps could be more compact. Most of the timestamps in a single log will share the same initial 7 or 8 digits. Also, I claim (without proof) that job logs tend to be written in batches (all close in time to one another) and would therefore benefit from delta compression.

Because terminal-to-html processes the stream of output, which is monotonic in time, into a "screen" with lines written to out-of-order, at least some of the logic for handling delta timestamps belongs here.