### PR TITLE
Pack style into uint32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4
+FROM golang:1.21.5
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/terminal-to-html/v3
 
-go 1.20
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/node.go
+++ b/node.go
@@ -1,15 +1,15 @@
 package terminal
 
-var emptyNode = node{blob: ' ', style: &emptyStyle}
+var emptyNode = node{blob: ' '}
 
 type node struct {
 	blob  rune
-	style *style
+	style style
 	elem  *element
 }
 
 func (n *node) hasSameStyle(o node) bool {
-	return n.style.isEqual(o.style)
+	return n.style == o.style
 }
 
 func (n *node) getRune() (rune, bool) {

--- a/output.go
+++ b/output.go
@@ -76,7 +76,7 @@ func outputLineAsHTML(line screenLine) string {
 	}
 
 	for idx, node := range line.nodes {
-		if idx == 0 && !node.style.isEmpty() {
+		if idx == 0 && node.style != 0 {
 			lineBuf.appendNodeStyle(node)
 			spanOpen = true
 		} else if idx > 0 {
@@ -86,7 +86,7 @@ func outputLineAsHTML(line screenLine) string {
 					lineBuf.closeStyle()
 					spanOpen = false
 				}
-				if !node.style.isEmpty() {
+				if node.style != 0 {
 					lineBuf.appendNodeStyle(node)
 					spanOpen = true
 				}

--- a/screen.go
+++ b/screen.go
@@ -16,7 +16,7 @@ type Screen struct {
 	screen []screenLine
 
 	// Current style
-	style *style
+	style style
 }
 
 type screenLine struct {
@@ -228,7 +228,7 @@ func (s *Screen) applyEscape(code rune, instructions []string) {
 
 // Parse ANSI input, populate our screen buffer with nodes
 func (s *Screen) Parse(ansi []byte) {
-	s.style = &emptyStyle
+	s.style = 0
 
 	parseANSIToScreen(s, ansi)
 }

--- a/screen.go
+++ b/screen.go
@@ -9,10 +9,14 @@ import (
 
 // A terminal 'screen'. Current cursor position, cursor style, and characters
 type Screen struct {
-	x      int
-	y      int
+	// Current cursor position
+	x, y int
+
+	// Screen contents
 	screen []screenLine
-	style  *style
+
+	// Current style
+	style *style
 }
 
 type screenLine struct {
@@ -73,7 +77,7 @@ func ansiInt(s string) int {
 // Move the cursor up, if we can
 func (s *Screen) up(i string) {
 	s.y -= ansiInt(i)
-	s.y = int(math.Max(0, float64(s.y)))
+	s.y = max(0, s.y)
 }
 
 // Move the cursor down
@@ -89,7 +93,7 @@ func (s *Screen) forward(i string) {
 // Move the cursor backward, if we can
 func (s *Screen) backward(i string) {
 	s.x -= ansiInt(i)
-	s.x = int(math.Max(0, float64(s.x)))
+	s.x = max(0, s.x)
 }
 
 func (s *Screen) getCurrentLineForWriting() *screenLine {

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -359,7 +359,7 @@ func TestRendererAgainstFixtures(t *testing.T) {
 }
 
 func TestScreenWriteToXY(t *testing.T) {
-	s := Screen{style: &emptyStyle}
+	s := Screen{style: 0}
 	s.write('a')
 
 	s.x = 1


### PR DESCRIPTION
The old node consists of the rune (`blob`), which is an int32, plus two pointers. On a 32-bit platform these align nicely. On 64-bit, the compiler typically wastes 4 bytes on padding for alignment.

Storing style as a packed int, and replacing *style with style, has a few benefits:
- blob + style is 8 bytes, and the remaining pointer takes it to 16 bytes
- comparison of styles is now a single integer comparison
- emptyStyle is now just 0

Also it's faster and uses less memory:

```plain
goos: linux
goarch: amd64
pkg: github.com/buildkite/terminal-to-html/v3
cpu: Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz
                      │ baseline.txt │             packed.txt              │
                      │    sec/op    │   sec/op     vs base                │
RendererControl-12       3.631µ ± 1%   2.898µ ± 1%  -20.19% (p=0.000 n=30)
RendererCurl-12          50.02µ ± 0%   46.34µ ± 0%   -7.34% (p=0.000 n=30)
RendererHomer-12        104.55µ ± 0%   90.86µ ± 0%  -13.09% (p=0.000 n=30)
RendererDockerPull-12    181.2µ ± 0%   167.9µ ± 0%   -7.37% (p=0.000 n=30)
RendererPikachu-12       5.030m ± 0%   4.766m ± 0%   -5.26% (p=0.000 n=30)
RendererNpm-12           80.98m ± 2%   81.00m ± 1%        ~ (p=0.697 n=30)
geomean                  334.5µ        304.1µ        -9.10%

                      │ baseline.txt  │              packed.txt              │
                      │     B/op      │     B/op      vs base                │
RendererControl-12       2.227Ki ± 0%   1.477Ki ± 0%  -33.68% (p=0.000 n=30)
RendererCurl-12         10.766Ki ± 0%   7.750Ki ± 0%  -28.01% (p=0.000 n=30)
RendererHomer-12         46.91Ki ± 0%   33.39Ki ± 0%  -28.81% (p=0.000 n=30)
RendererDockerPull-12    48.41Ki ± 0%   33.66Ki ± 0%  -30.47% (p=0.000 n=30)
RendererPikachu-12       767.6Ki ± 0%   652.4Ki ± 0%  -15.01% (p=0.000 n=30)
RendererNpm-12           24.26Mi ± 0%   18.44Mi ± 0%  -23.99% (p=0.000 n=30)
geomean                  100.6Ki        73.56Ki       -26.89%

                      │ baseline.txt │              packed.txt               │
                      │  allocs/op   │  allocs/op   vs base                  │
RendererControl-12        9.000 ± 0%    9.000 ± 0%        ~ (p=1.000 n=30) ¹
RendererCurl-12           36.00 ± 0%    35.00 ± 0%   -2.78% (p=0.000 n=30)
RendererHomer-12          134.0 ± 0%    133.0 ± 0%   -0.75% (p=0.000 n=30)
RendererDockerPull-12     193.0 ± 0%    193.0 ± 0%        ~ (p=1.000 n=30) ¹
RendererPikachu-12       16.16k ± 0%   14.35k ± 0%  -11.23% (p=0.000 n=30)
RendererNpm-12           183.2k ± 0%   158.9k ± 0%  -13.27% (p=0.000 n=30)
geomean                   540.1         514.0        -4.83%
¹ all samples are equal
```

```plain
goos: darwin
goarch: arm64
pkg: github.com/buildkite/terminal-to-html/v3
                      │ baseline-darwin-arm64.txt │       packed-darwin-arm64.txt       │
                      │          sec/op           │   sec/op     vs base                │
RendererControl-10                    620.6n ± 5%   556.3n ± 1%  -10.35% (p=0.000 n=30)
RendererCurl-10                       8.306µ ± 0%   7.644µ ± 0%   -7.98% (p=0.000 n=30)
RendererHomer-10                      19.65µ ± 0%   16.55µ ± 1%  -15.81% (p=0.000 n=30)
RendererDockerPull-10                 32.65µ ± 0%   28.96µ ± 2%  -11.30% (p=0.000 n=30)
RendererPikachu-10                    739.5µ ± 0%   682.2µ ± 1%   -7.75% (p=0.000 n=30)
RendererNpm-10                        15.24m ± 0%   13.43m ± 0%  -11.85% (p=0.000 n=30)
geomean                               57.79µ        51.51µ       -10.88%

                      │ baseline-darwin-arm64.txt │       packed-darwin-arm64.txt        │
                      │           B/op            │     B/op      vs base                │
RendererControl-10                   2.227Ki ± 0%   1.477Ki ± 0%  -33.68% (p=0.000 n=30)
RendererCurl-10                     10.766Ki ± 0%   7.750Ki ± 0%  -28.01% (p=0.000 n=30)
RendererHomer-10                     46.91Ki ± 0%   33.39Ki ± 0%  -28.81% (p=0.000 n=30)
RendererDockerPull-10                48.41Ki ± 0%   33.66Ki ± 0%  -30.47% (p=0.000 n=30)
RendererPikachu-10                   767.6Ki ± 0%   652.4Ki ± 0%  -15.01% (p=0.000 n=30)
RendererNpm-10                       24.26Mi ± 0%   18.44Mi ± 0%  -23.99% (p=0.000 n=30)
geomean                              100.6Ki        73.56Ki       -26.89%

                      │ baseline-darwin-arm64.txt │        packed-darwin-arm64.txt        │
                      │         allocs/op         │  allocs/op   vs base                  │
RendererControl-10                     9.000 ± 0%    9.000 ± 0%        ~ (p=1.000 n=30) ¹
RendererCurl-10                        36.00 ± 0%    35.00 ± 0%   -2.78% (p=0.000 n=30)
RendererHomer-10                       134.0 ± 0%    133.0 ± 0%   -0.75% (p=0.000 n=30)
RendererDockerPull-10                  193.0 ± 0%    193.0 ± 0%        ~ (p=1.000 n=30) ¹
RendererPikachu-10                    16.16k ± 0%   14.35k ± 0%  -11.23% (p=0.000 n=30)
RendererNpm-10                        183.2k ± 0%   158.9k ± 0%  -13.27% (p=0.000 n=30)
geomean                                540.1         514.0        -4.83%
¹ all samples are equal
```

```plain
goos: darwin
goarch: amd64
pkg: github.com/buildkite/terminal-to-html/v3
cpu: Intel(R) Xeon(R) W-2191B CPU @ 2.30GHz
                      │ baseline.txt │             packed.txt              │
                      │    sec/op    │   sec/op     vs base                │
RendererControl-36       1.606µ ± 0%   1.172µ ± 1%  -27.00% (p=0.000 n=30)
RendererCurl-36          14.29µ ± 0%   12.52µ ± 0%  -12.36% (p=0.000 n=30)
RendererHomer-36         40.22µ ± 0%   32.54µ ± 0%  -19.09% (p=0.000 n=30)
RendererDockerPull-36    54.76µ ± 0%   47.35µ ± 0%  -13.52% (p=0.000 n=30)
RendererPikachu-36       1.312m ± 0%   1.212m ± 0%   -7.64% (p=0.000 n=30)
RendererNpm-36           23.35m ± 1%   21.53m ± 0%   -7.76% (p=0.000 n=30)
geomean                  107.5µ        91.58µ       -14.84%

                      │ baseline.txt  │              packed.txt              │
                      │     B/op      │     B/op      vs base                │
RendererControl-36       2.227Ki ± 0%   1.477Ki ± 0%  -33.68% (p=0.000 n=30)
RendererCurl-36         10.766Ki ± 0%   7.750Ki ± 0%  -28.01% (p=0.000 n=30)
RendererHomer-36         46.91Ki ± 0%   33.39Ki ± 0%  -28.81% (p=0.000 n=30)
RendererDockerPull-36    48.41Ki ± 0%   33.66Ki ± 0%  -30.47% (p=0.000 n=30)
RendererPikachu-36       767.6Ki ± 0%   652.4Ki ± 0%  -15.01% (p=0.000 n=30)
RendererNpm-36           24.26Mi ± 0%   18.44Mi ± 0%  -23.99% (p=0.000 n=30)
geomean                  100.6Ki        73.56Ki       -26.89%

                      │ baseline.txt │              packed.txt               │
                      │  allocs/op   │  allocs/op   vs base                  │
RendererControl-36        9.000 ± 0%    9.000 ± 0%        ~ (p=1.000 n=30) ¹
RendererCurl-36           36.00 ± 0%    35.00 ± 0%   -2.78% (p=0.000 n=30)
RendererHomer-36          134.0 ± 0%    133.0 ± 0%   -0.75% (p=0.000 n=30)
RendererDockerPull-36     193.0 ± 0%    193.0 ± 0%        ~ (p=1.000 n=30) ¹
RendererPikachu-36       16.16k ± 0%   14.35k ± 0%  -11.23% (p=0.000 n=30)
RendererNpm-36           183.2k ± 0%   158.9k ± 0%  -13.27% (p=0.000 n=30)
geomean                   540.1         514.0        -4.83%
¹ all samples are equal
```