### PR TITLE
Store elements in screenLine

### DIFF
--- a/node.go
+++ b/node.go
@@ -2,19 +2,17 @@ package terminal
 
 var emptyNode = node{blob: ' '}
 
+// node represents an item in the screen. Most of the time, it is a single rune
+// which may or may not have a style (colour, bold, etc).
+// Sometimes it is a HTML element (e.g. from an inline image). This is encoded
+// by using style.element() == true and using blob as the index into a slice of
+// elements stored in the line.
 type node struct {
 	blob  rune
 	style style
-	elem  *element
 }
 
+// hasSameStyle reports if the two nodes have the same style.
 func (n *node) hasSameStyle(o node) bool {
-	return n.style == o.style
-}
-
-func (n *node) getRune() (rune, bool) {
-	if n.elem != nil {
-		return 0, false
-	}
-	return n.blob, true
+	return n.style&styleComparisonMask == o.style&styleComparisonMask
 }

--- a/output.go
+++ b/output.go
@@ -76,29 +76,29 @@ func outputLineAsHTML(line screenLine) string {
 	}
 
 	for idx, node := range line.nodes {
-		if idx == 0 && node.style != 0 {
-			lineBuf.appendNodeStyle(node)
-			spanOpen = true
-		} else if idx > 0 {
+		if idx == 0 {
+			if !node.style.isPlain() {
+				lineBuf.appendNodeStyle(node)
+				spanOpen = true
+			}
+		} else {
 			previous := line.nodes[idx-1]
 			if !node.hasSameStyle(previous) {
 				if spanOpen {
 					lineBuf.closeStyle()
 					spanOpen = false
 				}
-				if node.style != 0 {
+				if !node.style.isPlain() {
 					lineBuf.appendNodeStyle(node)
 					spanOpen = true
 				}
 			}
 		}
 
-		if elem := node.elem; elem != nil {
-			lineBuf.buf.WriteString(elem.asHTML())
-		}
-
-		if r, ok := node.getRune(); ok {
-			lineBuf.appendChar(r)
+		if node.style.element() {
+			lineBuf.buf.WriteString(line.elements[node.blob].asHTML())
+		} else {
+			lineBuf.appendChar(node.blob)
 		}
 	}
 	if spanOpen {

--- a/style.go
+++ b/style.go
@@ -5,8 +5,8 @@ import "strconv"
 type style uint32
 
 // style encoding:
-// 0...  ...7  8... ...15  16...23  24....31
-// [fg color]  [bg color]  [flags]  [unused]
+// 0...  ...7  8... ...15  16...23     24    25....31
+// [fg color]  [bg color]  [flags]  element  [unused]
 // flags = bold, faint, etc
 
 const (
@@ -18,7 +18,15 @@ const (
 	sbUnderline
 	sbStrike
 	sbBlink
+	sbElement // meaning: this node is actually an element
 )
+
+// Used for comparing styles - ignores the element bit.
+const styleComparisonMask = 0xffffff
+
+// isPlain reports if there is no style information. elements (that have no
+// other style set) are also considered plain.
+func (s style) isPlain() bool { return s&styleComparisonMask == 0 }
 
 func (s style) fgColor() uint8  { return uint8(s & 0xff) }
 func (s style) bgColor() uint8  { return uint8((s & 0xff_00) >> 8) }
@@ -30,6 +38,7 @@ func (s style) italic() bool    { return s&sbItalic != 0 }
 func (s style) underline() bool { return s&sbUnderline != 0 }
 func (s style) strike() bool    { return s&sbStrike != 0 }
 func (s style) blink() bool     { return s&sbBlink != 0 }
+func (s style) element() bool   { return s&sbElement != 0 }
 
 func (s *style) setFGColor(v uint8)  { *s = (*s &^ 0xff) | style(v) }
 func (s *style) setBGColor(v uint8)  { *s = (*s &^ 0xff_00) | (style(v) << 8) }
@@ -41,6 +50,7 @@ func (s *style) setItalic(v bool)    { *s = (*s &^ sbItalic) | booln(v, sbItalic
 func (s *style) setUnderline(v bool) { *s = (*s &^ sbUnderline) | booln(v, sbUnderline) }
 func (s *style) setStrike(v bool)    { *s = (*s &^ sbStrike) | booln(v, sbStrike) }
 func (s *style) setBlink(v bool)     { *s = (*s &^ sbBlink) | booln(v, sbBlink) }
+func (s *style) setElement(v bool)   { *s = (*s &^ sbElement) | booln(v, sbElement) }
 
 const (
 	COLOR_NORMAL        = iota


### PR DESCRIPTION
Here's another optimisation I thought of, aiming to reduce memory usage. This removes the element pointer in `node` and puts it in `screenLine`. On a 64-bit platform, this halves the size of `node` (16 bytes to 8 bytes) and increases `screenLine` by 24 bytes. Since most logs are pure text, this should be a win.

Like the last optimisation, it turns out this is also faster (between 3% - 15% on RendererNpm depending on platform). The memory allocation stats are identical between platforms.

Docker / Linux / AWS:
```plain
go: downloading github.com/google/go-cmp v0.5.9
goos: linux
goarch: amd64
pkg: github.com/buildkite/terminal-to-html/v3
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                     │ baseline-linux-amd64-aws.txt │  elementslice-linux-amd64-aws.txt   │
                     │            sec/op            │   sec/op     vs base                │
RendererControl-2                       1.937µ ± 4%   1.565µ ± 2%  -19.23% (p=0.000 n=30)
RendererCurl-2                          23.60µ ± 6%   20.13µ ± 5%  -14.70% (p=0.000 n=30)
RendererHomer-2                         55.09µ ± 4%   46.79µ ± 3%  -15.07% (p=0.000 n=30)
RendererDockerPull-2                    86.95µ ± 3%   71.55µ ± 3%  -17.71% (p=0.000 n=30)
RendererPikachu-2                       2.312m ± 2%   2.146m ± 5%   -7.20% (p=0.000 n=30)
RendererNpm-2                           47.16m ± 4%   41.49m ± 4%  -12.02% (p=0.000 n=30)
geomean                                 169.7µ        145.2µ       -14.41%

                     │ baseline-linux-amd64-aws.txt │   elementslice-linux-amd64-aws.txt   │
                     │             B/op             │     B/op      vs base                │
RendererControl-2                       1528.0 ± 0%     920.0 ± 0%  -39.79% (p=0.000 n=30)
RendererCurl-2                         7.766Ki ± 0%   5.438Ki ± 0%  -29.98% (p=0.000 n=30)
RendererHomer-2                        33.41Ki ± 0%   23.64Ki ± 0%  -29.23% (p=0.000 n=30)
RendererDockerPull-2                   33.67Ki ± 0%   21.66Ki ± 0%  -35.68% (p=0.000 n=30)
RendererPikachu-2                      652.4Ki ± 0%   563.9Ki ± 0%  -13.57% (p=0.000 n=30)
RendererNpm-2                          18.44Mi ± 0%   13.92Mi ± 0%  -24.55% (p=0.000 n=30)
geomean                                73.73Ki        52.14Ki       -29.28%

                     │ baseline-linux-amd64-aws.txt │   elementslice-linux-amd64-aws.txt   │
                     │          allocs/op           │  allocs/op   vs base                 │
RendererControl-2                        9.000 ± 0%    9.000 ± 0%       ~ (p=1.000 n=30) ¹
RendererCurl-2                           35.00 ± 0%    35.00 ± 0%       ~ (p=1.000 n=30) ¹
RendererHomer-2                          133.0 ± 0%    133.0 ± 0%       ~ (p=1.000 n=30) ¹
RendererDockerPull-2                     193.0 ± 0%    193.0 ± 0%       ~ (p=1.000 n=30) ¹
RendererPikachu-2                       14.35k ± 0%   14.35k ± 0%       ~ (p=1.000 n=30) ¹
RendererNpm-2                           158.9k ± 0%   158.9k ± 0%  +0.01% (p=0.000 n=30)
geomean                                  514.0         514.0       +0.00%
¹ all samples are equal
```

Linux / WSL / Intel i9-12900K:

```plain
goos: linux
goarch: amd64
pkg: github.com/buildkite/terminal-to-html/v3
cpu: 12th Gen Intel(R) Core(TM) i9-12900K
                      │ baseline-linux-amd64.txt │    elementslice-linux-amd64.txt     │
                      │          sec/op          │   sec/op     vs base                │
RendererControl-24                   369.8n ± 1%   300.3n ± 1%  -18.77% (p=0.000 n=30)
RendererCurl-24                      5.641µ ± 0%   4.886µ ± 0%  -13.38% (p=0.000 n=30)
RendererHomer-24                    11.392µ ± 0%   9.796µ ± 1%  -14.01% (p=0.000 n=30)
RendererDockerPull-24                20.15µ ± 0%   17.46µ ± 0%  -13.34% (p=0.000 n=30)
RendererPikachu-24                   516.8µ ± 0%   516.7µ ± 0%        ~ (p=0.476 n=30)
RendererNpm-24                      11.377m ± 1%   9.732m ± 0%  -14.46% (p=0.000 n=30)
geomean                              37.58µ        32.87µ       -12.51%
```

Linux / older Xeon:

```plain
goos: linux
goarch: amd64
pkg: github.com/buildkite/terminal-to-html/v3
cpu: Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz
                      │ packed-linux-amd64-mp.txt │   elementslice-linux-amd64-mp.txt   │
                      │          sec/op           │   sec/op     vs base                │
RendererControl-12                    2.898µ ± 1%   2.248µ ± 0%  -22.45% (p=0.000 n=30)
RendererCurl-12                       46.34µ ± 0%   43.65µ ± 0%   -5.82% (p=0.000 n=30)
RendererHomer-12                      90.86µ ± 0%   80.09µ ± 0%  -11.85% (p=0.000 n=30)
RendererDockerPull-12                 167.9µ ± 0%   152.4µ ± 0%   -9.22% (p=0.000 n=30)
RendererPikachu-12                    4.766m ± 0%   4.591m ± 0%   -3.66% (p=0.000 n=30)
RendererNpm-12                        81.00m ± 1%   77.86m ± 1%   -3.88% (p=0.000 n=30)
geomean                               304.1µ        274.5µ        -9.73%
```

macOS / M1 Max:

```plain
goos: darwin
goarch: arm64
pkg: github.com/buildkite/terminal-to-html/v3
                      │ baseline-darwin-arm64.txt │    elementslice-darwin-arm64.txt    │
                      │          sec/op           │   sec/op     vs base                │
RendererControl-10                    555.9n ± 1%   427.8n ± 0%  -23.05% (p=0.000 n=30)
RendererCurl-10                       8.152µ ± 0%   7.545µ ± 0%   -7.46% (p=0.000 n=30)
RendererHomer-10                      17.19µ ± 0%   15.06µ ± 0%  -12.36% (p=0.000 n=30)
RendererDockerPull-10                 29.59µ ± 0%   26.84µ ± 0%   -9.29% (p=0.000 n=30)
RendererPikachu-10                    687.4µ ± 0%   665.6µ ± 0%   -3.18% (p=0.000 n=30)
RendererNpm-10                        13.89m ± 0%   12.58m ± 0%   -9.48% (p=0.000 n=30)
geomean                               52.94µ        47.10µ       -11.03%
```

wasmtime (on macOS on M1 Max):

```plain
warning: this CLI invocation of Wasmtime is going to break in the future -- for
goos: wasip1
goarch: wasm
pkg: github.com/buildkite/terminal-to-html/v3
                   │ baseline-wasip1-wasm.txt │    elementslice-wasip1-wasm.txt     │
                   │          sec/op          │   sec/op     vs base                │
RendererControl                   12.70µ ± 0%   10.14µ ± 0%  -20.14% (p=0.000 n=30)
RendererCurl                      222.4µ ± 0%   201.1µ ± 0%   -9.58% (p=0.000 n=30)
RendererHomer                     399.2µ ± 0%   345.1µ ± 0%  -13.55% (p=0.000 n=30)
RendererDockerPull                752.7µ ± 0%   661.3µ ± 0%  -12.14% (p=0.000 n=30)
RendererPikachu                   18.00m ± 0%   17.39m ± 0%   -3.36% (p=0.000 n=30)
RendererNpm                       309.7m ± 3%   294.5m ± 0%   -4.92% (p=0.000 n=30)
geomean                           1.296m        1.156m       -10.80%
```