### PR TITLE
Streaming mode

### DIFF
--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -227,7 +227,8 @@ func main() {
 		},
 		&cli.IntFlag{
 			Name:  "buffer-max-lines",
-			Usage: "Sets a limit on the number of lines to hold in the screen buffer, allowing the renderer to operate in a streaming fashion and enabling the processing of large inputs",
+			Value: 300,
+			Usage: "Sets a limit on the number of lines to hold in the screen buffer, allowing the renderer to operate in a streaming fashion and enabling the processing of large inputs. Setting to 0 disables the limit, causing the renderer to buffer the entire screen before producing any output",
 		},
 	}
 	app.Action = func(c *cli.Context) error {

--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -194,7 +194,6 @@ func process(dst io.Writer, src io.Reader, preview bool, maxLines int) (in, out 
 	// Write what remains in the screen buffer (everything that didn't scroll
 	// out of the top).
 	fmt.Fprintln(wc, screen.AsHTML())
-	// TODO:	output := strings.Replace(screen.AsHTML(), "\n\n", "\n&nbsp;\n", -1)
 
 	if preview {
 		if err := writePreviewEnd(wc); err != nil {

--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -244,7 +244,7 @@ func main() {
 		input := os.Stdin
 		if args := c.Args(); args.Len() > 0 {
 			fpath := args.Get(0)
-			f, err := os.Open(args.Get(0))
+			f, err := os.Open(fpath)
 			if err != nil {
 				return fmt.Errorf("read %s: %w", fpath, err)
 			}

--- a/fixtures/pikachu.sh.rendered
+++ b/fixtures/pikachu.sh.rendered
@@ -1,4 +1,4 @@
-
+&nbsp;
                                                                             <span class="term-fgx52">0</span><span class="term-fgx59">101</span>
                                                                          <span class="term-fgx59">000001</span>
                                                                      <span class="term-fgx58">0</span><span class="term-fgx143">1</span><span class="term-fgx228">1</span><span class="term-fgx143">0</span><span class="term-fgx59">10001</span>
@@ -42,4 +42,5 @@
                           <span class="term-fgx58">1</span><span class="term-fgx179">0</span><span class="term-fgx221">00</span><span class="term-fgx227">100</span><span class="term-fgx221">0</span><span class="term-fgx179">0</span><span class="term-fgx136">0</span><span class="term-fgx58">0</span>                       <span class="term-fgx178">0</span><span class="term-fgx221">101</span><span class="term-fgx227">1</span><span class="term-fgx221">1</span><span class="term-fgx227">1</span><span class="term-fgx100">0</span>
                           <span class="term-fgx144">0</span><span class="term-fgx138">1</span><span class="term-fgx144">10</span><span class="term-fgx143">1</span><span class="term-fgx100">1</span><span class="term-fgx58">1</span>                            <span class="term-fgx94">0</span><span class="term-fgx222">11</span><span class="term-fgx179">1</span><span class="term-fgx228">0</span><span class="term-fgx143">0</span><span class="term-fgx180">0</span>
                                                                <span class="term-fgx59">0</span><span class="term-fgx102">1</span><span class="term-fgx144">0</span><span class="term-fgx187">0</span><span class="term-fgx101">0</span>
+&nbsp;
 &nbsp;

--- a/output.go
+++ b/output.go
@@ -1,7 +1,6 @@
 package terminal
 
 import (
-	"bytes"
 	"fmt"
 	"html"
 	"sort"
@@ -9,22 +8,22 @@ import (
 )
 
 type outputBuffer struct {
-	buf bytes.Buffer
+	buf strings.Builder
 }
 
 func (b *outputBuffer) appendNodeStyle(n node) {
-	b.buf.Write([]byte(`<span class="`))
+	b.buf.WriteString(`<span class="`)
 	for idx, class := range n.style.asClasses() {
 		if idx > 0 {
-			b.buf.Write([]byte(" "))
+			b.buf.WriteString(" ")
 		}
-		b.buf.Write([]byte(class))
+		b.buf.WriteString(class)
 	}
-	b.buf.Write([]byte(`">`))
+	b.buf.WriteString(`">`)
 }
 
 func (b *outputBuffer) closeStyle() {
-	b.buf.Write([]byte("</span>"))
+	b.buf.WriteString("</span>")
 }
 
 func (b *outputBuffer) appendMeta(namespace string, data map[string]string) {

--- a/output.go
+++ b/output.go
@@ -104,7 +104,11 @@ func (l *screenLine) asHTML() string {
 	if spanOpen {
 		lineBuf.closeStyle()
 	}
-	return strings.TrimRight(lineBuf.buf.String(), " \t")
+	line := strings.TrimRight(lineBuf.buf.String(), " \t")
+	if line == "" {
+		return "&nbsp;"
+	}
+	return line
 }
 
 // asPlain returns the line contents without any added HTML.

--- a/parser.go
+++ b/parser.go
@@ -77,7 +77,11 @@ type parser struct {
  */
 
 func (p *parser) parseToScreen(input []byte) {
-	p.buffer = append(p.buffer, input...)
+	if len(p.buffer) == 0 {
+		p.buffer = input
+	} else {
+		p.buffer = append(p.buffer, input...)
+	}
 
 	for p.cursor < len(p.buffer) {
 		char, charLen := utf8.DecodeRune(p.buffer[p.cursor:])

--- a/parser.go
+++ b/parser.go
@@ -20,9 +20,9 @@ type position struct {
 
 // Stateful ANSI parser
 type parser struct {
-	mode                 int
 	screen               *Screen
-	ansi                 []byte
+	buffer               []byte
+	mode                 int
 	cursor               int
 	escapeStartedAt      int
 	instructions         []string
@@ -45,12 +45,14 @@ type parser struct {
  * MODE_ESCAPE. The following character could start an escape sequence, a
  * control sequence, an operating system command, or be invalid or not understood.
  *
- * If we're in MODE_ESCAPE we look for three possible characters:
+ * If we're in MODE_ESCAPE we look for ~~three~~ eight possible characters:
  *
  * 1. For `[` we enter MODE_CONTROL and start looking for a control sequence.
  * 2. For `]` we enter MODE_OSC and look for an operating system command.
  * 3. For `(` or ')' we enter MODE_CHARSET and look for a character set name.
  * 4. For `_` we enter MODE_APC and parse the rest of the custom control sequence
+ * 5. For `M`, `7`, or `8`, we run an instruction directly (reverse newline,
+ *    or save/restore cursor).
  *
  * In all cases we start our instruction buffer. The instruction buffer is used
  * to store the individual characters that make up ANSI instructions before
@@ -74,12 +76,11 @@ type parser struct {
  * normally designate the character set.
  */
 
-func parseANSIToScreen(s *Screen, ansi []byte) {
-	p := parser{mode: MODE_NORMAL, ansi: ansi, screen: s}
-	p.mode = MODE_NORMAL
-	length := len(p.ansi)
-	for p.cursor = 0; p.cursor < length; {
-		char, charLen := utf8.DecodeRune(p.ansi[p.cursor:])
+func (p *parser) parseToScreen(input []byte) {
+	p.buffer = append(p.buffer, input...)
+
+	for p.cursor < len(p.buffer) {
+		char, charLen := utf8.DecodeRune(p.buffer[p.cursor:])
 
 		switch p.mode {
 		case MODE_ESCAPE:
@@ -104,12 +105,30 @@ func parseANSIToScreen(s *Screen, ansi []byte) {
 
 		p.cursor += charLen
 	}
+
+	// If we're in normal mode, everything up to the cursor has been procesed.
+	// If we're in the middle of an escape, everything up to p.escapeStartedAt
+	// has been processed.
+	done := p.escapeStartedAt
+	if p.mode == MODE_NORMAL {
+		done = p.cursor
+	}
+
+	// Drop the completed portion of the buffer.
+	p.buffer = p.buffer[done:]
+	p.cursor -= done
+	p.instructionStartedAt -= done
+	p.escapeStartedAt -= done
 }
 
-func (p *parser) handleCharset(char rune) {
+// handleCharset is called for each character consumed while in MODE_CHARSET.
+// It ignores the character and transitions back to MODE_NORMAL.
+func (p *parser) handleCharset(rune) {
 	p.mode = MODE_NORMAL
 }
 
+// handleOperatingSystemCommand is called for each character consumed while in
+// MODE_OSC. It does nothing until the OSC is terminated with an '\a'.
 func (p *parser) handleOperatingSystemCommand(char rune) {
 	if char != '\a' {
 		return
@@ -117,7 +136,7 @@ func (p *parser) handleOperatingSystemCommand(char rune) {
 	p.mode = MODE_NORMAL
 
 	// Bell received, stop parsing our potential image
-	image, err := parseElementSequence(string(p.ansi[p.instructionStartedAt:p.cursor]))
+	image, err := parseElementSequence(string(p.buffer[p.instructionStartedAt:p.cursor]))
 
 	if image == nil && err == nil {
 		// No image & no error, nothing to render
@@ -170,7 +189,7 @@ func (p *parser) handleApplicationProgramCommand(char rune) {
 
 	// APC terminator has been received; return to normal mode and handle the APC...
 	p.mode = MODE_NORMAL
-	sequence := string(p.ansi[p.instructionStartedAt:p.cursor])
+	sequence := string(p.buffer[p.instructionStartedAt:p.cursor])
 
 	// this might be a Buildkite Application Program Command sequence...
 	data, err := p.parseBuildkiteAPC(sequence)
@@ -186,6 +205,8 @@ func (p *parser) handleApplicationProgramCommand(char rune) {
 	p.screen.setLineMetadata(bkNamespace, data)
 }
 
+// handleControlSequence is called for each character consumed while in
+// MODE_CONTROL.
 func (p *parser) handleControlSequence(char rune) {
 	char = unicode.ToUpper(char)
 	switch char {
@@ -208,6 +229,7 @@ func (p *parser) handleControlSequence(char rune) {
 	}
 }
 
+// handleNormal is called for each character consumed while in MODE_NORMAL.
 func (p *parser) handleNormal(char rune) {
 	switch char {
 	case '\n':
@@ -224,6 +246,7 @@ func (p *parser) handleNormal(char rune) {
 	}
 }
 
+// handleEscape is called for each character consumed while in MODE_ESCAPE.
 func (p *parser) handleEscape(char rune) {
 	switch char {
 	case '[':
@@ -256,8 +279,10 @@ func (p *parser) handleEscape(char rune) {
 	}
 }
 
+// addInstruction appends an instruction to p.instructions, if the current
+// instruction is nonempty.
 func (p *parser) addInstruction() {
-	instruction := string(p.ansi[p.instructionStartedAt:p.cursor])
+	instruction := string(p.buffer[p.instructionStartedAt:p.cursor])
 	if instruction != "" {
 		p.instructions = append(p.instructions, instruction)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -69,7 +69,7 @@ func TestParseDECCursorSaveRestore(t *testing.T) {
 
 func parsedScreen(data string) *Screen {
 	s := &Screen{}
-	parseANSIToScreen(s, []byte(data))
+	s.Write([]byte(data))
 	return s
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -90,7 +90,7 @@ func assertXY(t *testing.T, s *Screen, x, y int) error {
 }
 
 func assertText(t *testing.T, s *Screen, expected string) error {
-	if actual := s.asPlainText(); actual != expected {
+	if actual := s.AsPlainText(); actual != expected {
 		return fmt.Errorf("expected text %q, got %q", expected, actual)
 	}
 	return nil

--- a/screen.go
+++ b/screen.go
@@ -1,7 +1,6 @@
 package terminal
 
 import (
-	"bytes"
 	"math"
 	"strconv"
 	"strings"
@@ -133,7 +132,7 @@ func (s *Screen) getCurrentLineForWriting() *screenLine {
 		baseY := len(s.screen) - s.MaxLines
 		if s.ScrollOutFunc != nil {
 			for _, l := range s.screen[:baseY] {
-				s.ScrollOutFunc(outputLineAsHTML(l))
+				s.ScrollOutFunc(l.asHTML())
 			}
 		}
 		s.LinesScrolledOut += baseY
@@ -298,29 +297,24 @@ func (s *Screen) Write(input []byte) (int, error) {
 
 // AsHTML returns the contents of the current screen buffer as HTML.
 func (s *Screen) AsHTML() string {
-	var lines []string
+	lines := make([]string, 0, len(s.screen))
 
 	for _, line := range s.screen {
-		lines = append(lines, outputLineAsHTML(line))
+		lines = append(lines, line.asHTML())
 	}
 
 	return strings.Join(lines, "\n")
 }
 
-// asPlainText renders the screen without any ANSI style etc.
-func (s *Screen) asPlainText() string {
-	var buf bytes.Buffer
-	for i, line := range s.screen {
-		for _, node := range line.nodes {
-			if !node.style.element() {
-				buf.WriteRune(node.blob)
-			}
-		}
-		if i < len(s.screen)-1 {
-			buf.WriteRune('\n')
-		}
+// AsPlainText renders the screen without any ANSI style etc.
+func (s *Screen) AsPlainText() string {
+	lines := make([]string, 0, len(s.screen))
+
+	for _, line := range s.screen {
+		lines = append(lines, line.asPlain())
 	}
-	return strings.TrimRight(buf.String(), " \t")
+
+	return strings.Join(lines, "\n")
 }
 
 func (s *Screen) newLine() {

--- a/screen.go
+++ b/screen.go
@@ -144,7 +144,8 @@ func (s *Screen) getCurrentLineForWriting() *screenLine {
 
 		// Trim the first line off the top of the screen.
 		// Recycle its nodes slice to make a new line on the bottom.
-		s.screen = append(s.screen[1:], screenLine{nodes: s.screen[0].nodes[:0]})
+		newLine := screenLine{nodes: s.screen[0].nodes[:0]}
+		s.screen = append(s.screen[1:], newLine)
 		s.y--
 	}
 

--- a/terminal.go
+++ b/terminal.go
@@ -10,12 +10,9 @@ GO111MODULE=on go install github.com/buildkite/terminal-to-html/v3/cmd/terminal-
 */
 package terminal
 
-import "strings"
-
 // Render converts ANSI to HTML and returns the result.
 func Render(input []byte) string {
 	screen := Screen{}
 	screen.Write(input)
-	output := strings.Replace(screen.AsHTML(), "\n\n", "\n&nbsp;\n", -1)
-	return output
+	return screen.AsHTML()
 }

--- a/terminal.go
+++ b/terminal.go
@@ -10,12 +10,12 @@ GO111MODULE=on go install github.com/buildkite/terminal-to-html/v3/cmd/terminal-
 */
 package terminal
 
-import "bytes"
+import "strings"
 
 // Render converts ANSI to HTML and returns the result.
-func Render(input []byte) []byte {
+func Render(input []byte) string {
 	screen := Screen{}
-	screen.Parse(input)
-	output := bytes.Replace(screen.AsHTML(), []byte("\n\n"), []byte("\n&nbsp;\n"), -1)
+	screen.Write(input)
+	output := strings.Replace(screen.AsHTML(), "\n\n", "\n&nbsp;\n", -1)
 	return output
 }

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -382,20 +382,43 @@ func TestScreenWriteToXY(t *testing.T) {
 	}
 }
 
-func BenchmarkRendererControl(b *testing.B)    { benchmark("control.sh", b) }
-func BenchmarkRendererCurl(b *testing.B)       { benchmark("curl.sh", b) }
-func BenchmarkRendererHomer(b *testing.B)      { benchmark("homer.sh", b) }
-func BenchmarkRendererDockerPull(b *testing.B) { benchmark("docker-pull.sh", b) }
-func BenchmarkRendererPikachu(b *testing.B)    { benchmark("pikachu.sh", b) }
-func BenchmarkRendererPlaywright(b *testing.B) { benchmark("playwright.sh", b) }
-func BenchmarkRendererRustFmt(b *testing.B)    { benchmark("rustfmt.sh", b) }
-func BenchmarkRendererWeather(b *testing.B)    { benchmark("weather.sh", b) }
-func BenchmarkRendererNpm(b *testing.B)        { benchmark("npm.sh", b) }
+func BenchmarkRendererControl(b *testing.B)    { benchmarkRender("control.sh", b) }
+func BenchmarkRendererCurl(b *testing.B)       { benchmarkRender("curl.sh", b) }
+func BenchmarkRendererHomer(b *testing.B)      { benchmarkRender("homer.sh", b) }
+func BenchmarkRendererDockerPull(b *testing.B) { benchmarkRender("docker-pull.sh", b) }
+func BenchmarkRendererPikachu(b *testing.B)    { benchmarkRender("pikachu.sh", b) }
+func BenchmarkRendererPlaywright(b *testing.B) { benchmarkRender("playwright.sh", b) }
+func BenchmarkRendererRustFmt(b *testing.B)    { benchmarkRender("rustfmt.sh", b) }
+func BenchmarkRendererWeather(b *testing.B)    { benchmarkRender("weather.sh", b) }
+func BenchmarkRendererNpm(b *testing.B)        { benchmarkRender("npm.sh", b) }
 
-func benchmark(filename string, b *testing.B) {
+func benchmarkRender(filename string, b *testing.B) {
 	raw := loadFixture(b, filename, "raw")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = Render(raw)
+	}
+}
+
+func BenchmarkStreamingControl(b *testing.B)    { benchmarkStreaming("control.sh", b) }
+func BenchmarkStreamingCurl(b *testing.B)       { benchmarkStreaming("curl.sh", b) }
+func BenchmarkStreamingHomer(b *testing.B)      { benchmarkStreaming("homer.sh", b) }
+func BenchmarkStreamingDockerPull(b *testing.B) { benchmarkStreaming("docker-pull.sh", b) }
+func BenchmarkStreamingPikachu(b *testing.B)    { benchmarkStreaming("pikachu.sh", b) }
+func BenchmarkStreamingPlaywright(b *testing.B) { benchmarkStreaming("playwright.sh", b) }
+func BenchmarkStreamingRustFmt(b *testing.B)    { benchmarkStreaming("rustfmt.sh", b) }
+func BenchmarkStreamingWeather(b *testing.B)    { benchmarkStreaming("weather.sh", b) }
+func BenchmarkStreamingNpm(b *testing.B)        { benchmarkStreaming("npm.sh", b) }
+
+func benchmarkStreaming(filename string, b *testing.B) {
+	raw := loadFixture(b, filename, "raw")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s := &Screen{
+			MaxLines:      300,
+			ScrollOutFunc: func(string) {},
+		}
+		s.Write(raw)
+		_ = s.AsHTML()
 	}
 }


### PR DESCRIPTION
### The goal
Allow terminal output to be processed in a streaming manner, at the expense of not buffering the full history of the input. Enable much larger input to be processed without exhausting memory.

### Why
The memory improvements of the last couple of PRs (#121, #124) whittle the memory allocated per run for the NPM benchmark from ~24MiB down to ~14MiB, but on a ~0.5MiB input that's still a hefty blowup. 

The overwhelming amount of typical terminal output writes to new lines. Sometimes a command on a PTY will erase the previous line (e.g. `git`). Some tools will rewrite the last 10 or so lines (`bazel`, `docker`). In all cases, sensible CLI tools should assume the terminal window is no larger than a few hundred lines. 

So why do we need to buffer more lines than that?

By streaming out all the lines we no longer need to touch, they don't need to be kept in memory, so they can be freed. The total memory needed to process input can be limited, rather than having to scale with the size of the input. This will enable displaying much larger logs.

### How
The key functionality was added in #118; the main change is to tidy up the main edge case (preserving parser state between chunks of input) and default to using it. Pass `--buffer-max-lines=0` to disable the line limit. It applies to all modes: stdin, file, and the web service.

### But while I'm here...
* Add some tests and benchmarks for the new streaming approach
* Use `strings.Builder` instead of `bytes.Buffer`, and avoid a few casts to `[]byte` - it's slightly faster
* Change how the scroll-out works, to reuse previously allocated screen lines
* Remove the `strings.Replace` that inserted `&nbsp;` by generating `&nbsp;` for every line that would have been empty.

### Show me the benchmarks!

```plain
goos: darwin
goarch: arm64
pkg: github.com/buildkite/terminal-to-html/v3
                │ before.txt  │              after.txt              │
                │   sec/op    │   sec/op     vs base                │
RendererNpm-10    12.88m ± 1%   12.02m ± 0%   -6.64% (p=0.000 n=30)
StreamingNpm-10   13.64m ± 0%   11.31m ± 1%  -17.08% (p=0.000 n=30)
geomean           13.25m        11.66m       -12.02%

                │  before.txt   │              after.txt               │
                │     B/op      │     B/op      vs base                │
RendererNpm-10     13.92Mi ± 0%   11.19Mi ± 0%  -19.56% (p=0.000 n=30)
StreamingNpm-10   10.633Mi ± 0%   5.675Mi ± 0%  -46.62% (p=0.000 n=30)
geomean            12.16Mi        7.971Mi       -34.47%

                │ before.txt  │             after.txt              │
                │  allocs/op  │  allocs/op   vs base               │
RendererNpm-10    158.9k ± 0%   163.9k ± 0%  +3.14% (p=0.000 n=30)
StreamingNpm-10   158.9k ± 0%   158.2k ± 0%  -0.46% (p=0.000 n=30)
geomean           158.9k        161.0k       +1.32%
```

The streaming benchmark doesn't exist before this PR, so I copied it into main temporarily (and fixed it so it would build). The speedups are mostly to do with `strings.Builder` and avoiding casts to `[]byte`. The 46% memory saving before/after in the streaming benchmark is primarily due to the screen line recycling. 