### PR TITLE
Report resource and processing stats to stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5
+FROM public.ecr.aws/docker/library/golang:1.22.0@sha256:7b297d9abee021bab9046e492506b3c2da8a3722cbf301653186545ecc1e00bb
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	golang.org/x/sys v0.17.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/terminal-to-html/v3
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=
 github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/rusage/rusage.go
+++ b/internal/rusage/rusage.go
@@ -1,0 +1,24 @@
+// Package rusage is a small wrapper around the POSIX system call getrusage.
+package rusage
+
+import "time"
+
+// Resources summarises used system resources (mainly CPU time and memory).
+// Some fields that appear in various rusage structs are omitted because we
+// mainly care about Linux.
+type Resources struct {
+	// User-mode time and system-mode time
+	Utime, Stime time.Duration
+
+	// Maximum resident segment size, in platform-dependent units:
+	// - Linux, Dragonfly, FreeBSD, NetBSD, OpenBSD, AIX: kilobytes
+	// - Darwin: bytes
+	// - Solaris, Illumos: pages
+	MaxRSS int64
+
+	// Counts of minor and major page faults
+	MinorFaults, MajorFaults int64
+
+	// Counts of file system performing input / output
+	FSInBlocks, FSOutBlocks int64
+}

--- a/internal/rusage/rusage_nonunix.go
+++ b/internal/rusage/rusage_nonunix.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package rusage
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Stats reports a "not implemented" error.
+func Stats() (*Resources, error) {
+	return nil, fmt.Errorf("not implemented for %s", runtime.GOOS)
+}

--- a/internal/rusage/rusage_unix.go
+++ b/internal/rusage/rusage_unix.go
@@ -1,0 +1,29 @@
+//go:build unix
+
+package rusage
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// Stats returns the resources used by the program according to getrusage(2).
+func Stats() (*Resources, error) {
+	var usage unix.Rusage
+	if err := unix.Getrusage(unix.RUSAGE_SELF, &usage); err != nil {
+		return nil, err
+	}
+
+	return &Resources{
+		Utime: time.Duration(usage.Utime.Nano()),
+		Stime: time.Duration(usage.Stime.Nano()),
+
+		// Note: These integer casts aren't redundant on 32-bit arches
+		MaxRSS:      int64(usage.Maxrss),
+		MinorFaults: int64(usage.Minflt),
+		MajorFaults: int64(usage.Majflt),
+		FSInBlocks:  int64(usage.Inblock),
+		FSOutBlocks: int64(usage.Oublock),
+	}, nil
+}


### PR DESCRIPTION
More data is needed in order to quantify the impact of changes like #126 on real-world terminal output.

- How much CPU time (as distinct from wall-clock time) is needed? How much in the system, how much in the process itself?
- What about memory consumption? Allocations, frees?
- Filesystem accesses? Page faults? Garbage collection?
- How often do cursor move commands try to scroll out of bounds? What if we set `MaxLines`?

Pass `--log-stats-to-stderr`, receive JSON object with stats on stderr.

Example:

```shell
% cat fixtures/npm.sh.raw | go run ./cmd/terminal-to-html --log-stats-to-stderr > /dev/null 
{"Rtime":19621916,"Utime":21790000,"Stime":7932000,"MaxRSS":24461312,"MinorFaults":1720,"MajorFaults":0,"FSInBlocks":0,"FSOutBlocks":0,"InputBytes":558760,"OutputBytes":933880,"LinesScrolledOut":0,"CursorUpOOB":0,"CursorBackOOB":0,"TotalAlloc":19199720,"HeapAlloc":10241080,"HeapInuse":11411456,"Mallocs":160501,"Frees":136811,"PauseTotalNs":220376,"NumGC":4,"GCCPUFraction":0.019161677967035995}
```