### PR TITLE
Update to Go 1.22 and use ECR image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5
+FROM public.ecr.aws/docker/library/golang:1.22.0@sha256:7b297d9abee021bab9046e492506b3c2da8a3722cbf301653186545ecc1e00bb
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/terminal-to-html/v3
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
* Fix builds that fail due to docker hub limits
* Embrace modernity