### PR TITLE
Run jobs on the hosted queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: hosted
+
 steps:
   - name: ":bomb: Test"
     command: make test


### PR DESCRIPTION
We're experimenting with a new queue, and slowly shifting work over to it. I expect this should Just Work, but it's safe to revert if the new agents cause any trouble.