### PR TITLE
Bump version to v3.12.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.11.0"
+var baseVersion string = "3.12.0"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.12.0](https://github.com/buildkite/terminal-to-html/tree/v3.12.0) (2024-05-07)
[Full Changelog](https://github.com/buildkite/terminal-to-html/compare/v3.11.0...v3.12.0)

### Changed
- Streaming mode [#126](https://github.com/buildkite/terminal-to-html/pull/126) (@DrJosh9000)

#### Internal
- Run jobs on the hosted queue [#147](https://github.com/buildkite/terminal-to-html/pull/147) (@yob)

#### Dependabot
- Bump golang.org/x/sys from 0.19.0 to 0.20.0 [#149](https://github.com/buildkite/terminal-to-html/pull/149) (@dependabot[bot])
- Bump github.com/urfave/cli/v2 from 2.27.1 to 2.27.2 [#144](https://github.com/buildkite/terminal-to-html/pull/144) (@dependabot[bot])
- Bump docker/library/golang from `450e382` to `d5302d4` [#145](https://github.com/buildkite/terminal-to-html/pull/145) (@dependabot[bot])
- Bump docker/library/golang from `c4fb952` to `450e382` [#142](https://github.com/buildkite/terminal-to-html/pull/142) (@dependabot[bot])
- Bump docker/library/golang from 1.22.1 to 1.22.2 [#141](https://github.com/buildkite/terminal-to-html/pull/141) (@dependabot[bot])
- Bump golang.org/x/sys from 0.18.0 to 0.19.0 [#140](https://github.com/buildkite/terminal-to-html/pull/140) (@dependabot[bot])
- Bump docker/library/golang from 1.22.0 to 1.22.1 [#137](https://github.com/buildkite/terminal-to-html/pull/137) (@dependabot[bot])
- Bump golang.org/x/sys from 0.17.0 to 0.18.0 [#136](https://github.com/buildkite/terminal-to-html/pull/136) (@dependabot[bot])
