### PR TITLE
Fix trailing newline diff

### DIFF
--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -193,7 +193,7 @@ func process(dst io.Writer, src io.Reader, preview bool, maxLines int) (in, out 
 
 	// Write what remains in the screen buffer (everything that didn't scroll
 	// out of the top).
-	fmt.Fprintln(wc, screen.AsHTML())
+	fmt.Fprint(wc, screen.AsHTML())
 
 	if preview {
 		if err := writePreviewEnd(wc); err != nil {


### PR DESCRIPTION
`fmt.Println` here was inserting a trailing newline after `screen.AsHTML()`, but all the tests that show equivalence with non-streaming didn't do that.