### PR TITLE
Handle ESC \ string terminators in OSC and APC

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -44,10 +44,34 @@ func TestParseAPCPrefix(t *testing.T) {
 	}
 }
 
+// Application Program Command can be terminated with ESC \
+func TestParseAPCWithSTPrefix(t *testing.T) {
+	s := parsedScreen("\x1b_bk;t=0\x1b\\hello")
+	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+		t.Error(err)
+	}
+}
+
 // Application Program Command should be zero-width for cursor movement
 func TestParseXYAfterCursorMovementThroughBuildkiteTimestampAPC(t *testing.T) {
 	s := parsedScreen("hel\x1b_bk;t=0\x07lo\x1b[4D3")
 	if err := assertTextXY(t, s, "h3llo", 2, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+// Operating System Command can be terminated with BEL
+func TestParseOSCHyperlink(t *testing.T) {
+	s := parsedScreen("\x1b]8;;http://example.com/\x07hello")
+	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+// Operating System Command can be terminated with ESC \
+func TestParseOSCWithST(t *testing.T) {
+	s := parsedScreen("\x1b]8;;http://example.com/\x1b\\hello")
+	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
 }

--- a/screen.go
+++ b/screen.go
@@ -296,7 +296,7 @@ func (s *Screen) applyEscape(code rune, instructions []string) {
 func (s *Screen) Write(input []byte) (int, error) {
 	if s.parser == nil {
 		s.parser = &parser{
-			mode:   MODE_NORMAL,
+			mode:   parserModeNormal,
 			screen: s,
 		}
 	}


### PR DESCRIPTION
Fixes #101 - note the description of #101 is a bit off. `0x9C` is historical as a string terminator (ST), but [a common ST in use today](https://iterm2.com/3.2/documentation-escape-codes.html) (e.g. for hyperlinks with the extension `ESC ]8;;link ST`) is actually the two byte sequence `ESC \`.

This is relevant to #58 as this is a step towards accepting  at least one hyperlink extension known to iTerm (and others) in its possible forms. However this PR will break [this amazing hack](https://github.com/buildkite/terminal-to-html/issues/58#issuecomment-1998933219)...

This PR includes a small tidyup of the parser modes enum. We [don't use shouty-case constants](https://google.github.io/styleguide/go/decisions#constant-names) in Go.

