### PR TITLE
Bump version for v3.13.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.12.1"
+var baseVersion string = "3.13.0"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.13.0](https://github.com/buildkite/terminal-to-html/tree/v3.13.0) (2024-07-03)
[Full Changelog](https://github.com/buildkite/terminal-to-html/compare/v3.12.1...v3.13.0)

### Changed
- Handle ESC \ string terminators in OSC and APC [#159](https://github.com/buildkite/terminal-to-html/pull/159) (@DrJosh9000)

### Dependency churn
- Bump docker/library/golang from 1.22.4 to 1.22.5 [#162](https://github.com/buildkite/terminal-to-html/pull/162) (@dependabot[bot])
- Bump docker/library/golang from `969349b` to `c2010b9` [#157](https://github.com/buildkite/terminal-to-html/pull/157) (@dependabot[bot])
- Bump golang.org/x/sys from 0.20.0 to 0.21.0 [#155](https://github.com/buildkite/terminal-to-html/pull/155) (@dependabot[bot])
- Bump docker/library/golang from 1.22.3 to 1.22.4 [#156](https://github.com/buildkite/terminal-to-html/pull/156) (@dependabot[bot])
- Bump docker/library/golang from `b1e05e2` to `f43c6f0` [#154](https://github.com/buildkite/terminal-to-html/pull/154) (@dependabot[bot])
- Bump docker/library/golang from 1.22.2 to 1.22.3 [#153](https://github.com/buildkite/terminal-to-html/pull/153) (@dependabot[bot])
