### PR TITLE
Add iTerm-style hyperlinks

### DIFF
--- a/element.go
+++ b/element.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	ELEMENT_ITERM_IMAGE = iota
-	ELEMENT_IMAGE
-	ELEMENT_LINK
+	elementITermImage = iota
+	elementImage
+	elementLink
 )
 
 type element struct {
@@ -30,7 +30,7 @@ var errUnsupportedElementSequence = errors.New("Unsupported element sequence")
 func (i *element) asHTML() string {
 	h := html.EscapeString
 
-	if i.elementType == ELEMENT_LINK {
+	if i.elementType == elementLink {
 		content := i.content
 		if content == "" {
 			content = i.url
@@ -46,10 +46,11 @@ func (i *element) asHTML() string {
 	parts := []string{fmt.Sprintf(`alt="%s"`, h(alt))}
 
 	switch i.elementType {
-	case ELEMENT_ITERM_IMAGE:
+	case elementITermImage:
 		src := fmt.Sprintf(`src="data:%s;base64,%s"`, h(i.contentType), h(i.content))
 		parts = append(parts, src)
-	case ELEMENT_IMAGE:
+
+	case elementImage:
 		url := sanitizeURL(i.url)
 		if url == "" || url == unsafeURLSubstitution {
 			// don't emit an <img> at all if the URL is empty or didn't sanitize
@@ -57,6 +58,7 @@ func (i *element) asHTML() string {
 		}
 		src := fmt.Sprintf(`src="%s"`, h(url))
 		parts = append(parts, src)
+
 	default:
 		// unreachable, but…
 		return ""
@@ -125,7 +127,7 @@ func parseElementSequence(sequence string) (*element, error) {
 		}
 	}
 
-	if elem.elementType == ELEMENT_ITERM_IMAGE {
+	if elem.elementType == elementITermImage {
 		if elem.url == "" {
 			return nil, fmt.Errorf("name= argument not supplied, required to determine content type")
 		}
@@ -138,7 +140,7 @@ func parseElementSequence(sequence string) (*element, error) {
 		}
 	}
 
-	if elem.elementType == ELEMENT_ITERM_IMAGE && !imageInline {
+	if elem.elementType == elementITermImage && !imageInline {
 		// in iTerm2, if you don't specify inline=1, the image is merely downloaded
 		// and not displayed.
 		elem = nil
@@ -165,10 +167,10 @@ func parseImageDimension(s string) string {
 
 func splitAndVerifyElementSequence(s string) (arguments string, elementType int, content string, err error) {
 	if strings.HasPrefix(s, "1338;") {
-		return s[len("1338;"):], ELEMENT_IMAGE, "", nil
+		return s[len("1338;"):], elementImage, "", nil
 	}
 	if strings.HasPrefix(s, "1339;") {
-		return s[len("1339;"):], ELEMENT_LINK, "", nil
+		return s[len("1339;"):], elementLink, "", nil
 	}
 
 	prefixLen := len("1337;File=")
@@ -182,7 +184,7 @@ func splitAndVerifyElementSequence(s string) (arguments string, elementType int,
 		return "", 0, "", fmt.Errorf("expected sequence to have one arguments part and one content part, got %d part(s)", len(parts))
 	}
 
-	elementType = ELEMENT_ITERM_IMAGE
+	elementType = elementITermImage
 	arguments = parts[0]
 	content = parts[1]
 	if len(content) == 0 {

--- a/element.go
+++ b/element.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	elementITermImage = iota
+	elementITermLink
 	elementImage
 	elementLink
 )
@@ -76,6 +77,7 @@ func (i *element) asHTML() string {
 
 func parseElementSequence(sequence string) (*element, error) {
 	// Expect:
+	// - iTerm style hyperlink:    8;(params);(url)
 	// - iTerm style inline image: 1337;File=name=1.gif;inline=1:BASE64
 	// - Buildkite external image: 1338;url=…;alt=…;width=…;height=…
 	// - Buildkite hyperlink:      1339;url=…;content=…
@@ -93,9 +95,22 @@ func parseElementSequence(sequence string) (*element, error) {
 		return nil, err
 	}
 
-	imageInline := false
-
 	elem := &element{content: content, elementType: elementType}
+
+	if elementType == elementITermLink {
+		// For "iTerm" links (OSC 8), the tokens[0] is params and tokens[1] is the URL.
+		// We ignore params. The link "content" comes after the element and is stored
+		// as regular text in the screen line, because they are designed to gracefully
+		// degrade to plain text if the sequence isn't supported.
+		if len(tokens) != 2 {
+			// Probably malformed
+			return nil, nil
+		}
+		elem.url = tokens[1]
+		return elem, nil
+	}
+
+	imageInline := false
 
 	for _, token := range tokens {
 		parts := strings.SplitN(token, "=", 2)
@@ -166,18 +181,21 @@ func parseImageDimension(s string) string {
 }
 
 func splitAndVerifyElementSequence(s string) (arguments string, elementType int, content string, err error) {
-	if strings.HasPrefix(s, "1338;") {
-		return s[len("1338;"):], elementImage, "", nil
+	if rem, has := strings.CutPrefix(s, "8;"); has {
+		return rem, elementITermLink, "", nil
 	}
-	if strings.HasPrefix(s, "1339;") {
-		return s[len("1339;"):], elementLink, "", nil
+	if rem, has := strings.CutPrefix(s, "1338;"); has {
+		return rem, elementImage, "", nil
+	}
+	if rem, has := strings.CutPrefix(s, "1339;"); has {
+		return rem, elementLink, "", nil
 	}
 
-	prefixLen := len("1337;File=")
-	if !strings.HasPrefix(s, "1337;File=") {
+	rem, has := strings.CutPrefix(s, "1337;File=")
+	if !has {
 		return "", 0, "", errUnsupportedElementSequence
 	}
-	s = s[prefixLen:]
+	s = rem
 
 	parts := strings.Split(s, ":")
 	if len(parts) != 2 {

--- a/element_test.go
+++ b/element_test.go
@@ -77,7 +77,7 @@ var validCases = []struct {
 	}, {
 		`1337: image with name, content & inline`,
 		`1337;File=name=Zm9vLmdpZg==;inline=1:AA==`,
-		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", elementType: ELEMENT_ITERM_IMAGE},
+		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", elementType: elementITermImage},
 	}, {
 		`1337: image without inline=1 does not render`,
 		`1337;File=name=Zm9vLmdpZg==:AA==`,
@@ -85,59 +85,59 @@ var validCases = []struct {
 	}, {
 		`1337: adapts content type based on image name`,
 		`1337;File=name=` + base64Encode("foo.jpg") + `;inline=1:AA==`,
-		&element{url: "foo.jpg", content: "AA==", contentType: "image/jpeg", elementType: ELEMENT_ITERM_IMAGE},
+		&element{url: "foo.jpg", content: "AA==", contentType: "image/jpeg", elementType: elementITermImage},
 	}, {
 		`1337: handles width & height`,
 		`1337;File=name=Zm9vLmdpZg==;width=100%;height=50px;inline=1:AA==`,
-		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", width: "100%", height: "50px", elementType: ELEMENT_ITERM_IMAGE},
+		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", width: "100%", height: "50px", elementType: elementITermImage},
 	}, {
 		`1337: parsing is NOT concerned with XSS in image name, width & height by stripping brackets, because that's protected at render time`,
 		`1337;File=name=` + base64Encode(`foo".gif`) + `;width="100%";height='50px'>;inline=1:AA==`,
-		&element{url: `foo".gif`, content: "AA==", contentType: "image/gif", width: "100%", height: "50px>em", elementType: ELEMENT_ITERM_IMAGE},
+		&element{url: `foo".gif`, content: "AA==", contentType: "image/gif", width: "100%", height: "50px>em", elementType: elementITermImage},
 	}, {
 		`1337: converts width & height without percent or px to em`,
 		`1337;File=name=Zm9vLmdpZg==;width=1;height=5;inline=1:AA==`,
-		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", width: "1em", height: "5em", elementType: ELEMENT_ITERM_IMAGE},
+		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", width: "1em", height: "5em", elementType: elementITermImage},
 	}, {
 		`1337: malfored arguments are silently ignored`,
 		`1337;File=name=Zm9vLmdpZg==;inline=1;sdfsdfs;====ddd;herp=derps:AA==`,
-		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", elementType: ELEMENT_ITERM_IMAGE},
+		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", elementType: elementITermImage},
 	}, {
 		`1338: image with filename`,
 		"1338;url=tmp/foo.gif",
-		&element{url: "tmp/foo.gif", elementType: ELEMENT_IMAGE},
+		&element{url: "tmp/foo.gif", elementType: elementImage},
 	}, {
 		`1338: image with filename containing an escaped ;`,
 		"1338;url=tmp/foo\\;bar.gif",
-		&element{url: "tmp/foo;bar.gif", elementType: ELEMENT_IMAGE},
+		&element{url: "tmp/foo;bar.gif", elementType: elementImage},
 	}, {
 		`1338: image with filename, width, height & alt tag`,
 		"1338;url=foo.gif;width=50px;height=50px;alt=foo gif",
-		&element{url: "foo.gif", width: "50px", height: "50px", alt: "foo gif", elementType: ELEMENT_IMAGE},
+		&element{url: "foo.gif", width: "50px", height: "50px", alt: "foo gif", elementType: elementImage},
 	}, {
 		`1339: link with url only`,
 		"1339;url=foo.gif",
-		&element{url: "foo.gif", elementType: ELEMENT_LINK},
+		&element{url: "foo.gif", elementType: elementLink},
 	}, {
 		`1339: link with url and content`,
 		"1339;url=foo.gif;content=bar",
-		&element{url: "foo.gif", content: "bar", elementType: ELEMENT_LINK},
+		&element{url: "foo.gif", content: "bar", elementType: elementLink},
 	}, {
 		`1339: link in quotes with url only`,
 		"1339;url='foo.gif'",
-		&element{url: "foo.gif", elementType: ELEMENT_LINK},
+		&element{url: "foo.gif", elementType: elementLink},
 	}, {
 		`1339: link in quotes with url and content`,
 		"1339;url='foo.gif';content=bar",
-		&element{url: "foo.gif", content: "bar", elementType: ELEMENT_LINK},
+		&element{url: "foo.gif", content: "bar", elementType: elementLink},
 	}, {
 		`1339: link with url and content in quotes`,
 		"1339;url='foo.gif';content='bar'",
-		&element{url: "foo.gif", content: "bar", elementType: ELEMENT_LINK},
+		&element{url: "foo.gif", content: "bar", elementType: elementLink},
 	}, {
 		`1339: link in quotes with semicolon in url`,
 		"1339;url='foo.gif?weirdparams=something;somethingelse'",
-		&element{url: "foo.gif?weirdparams=something;somethingelse", elementType: ELEMENT_LINK},
+		&element{url: "foo.gif?weirdparams=something;somethingelse", elementType: elementLink},
 	}, {
 		`1339: link with HTML special characters in attributes`,
 		`1339;url=https://example.com/a?b=<c>&d=e#f;height="<hello>";width=<world%>;alt=&;content=<h1>heading</h1>`,
@@ -147,7 +147,7 @@ var validCases = []struct {
 			content:     "<h1>heading</h1>",
 			height:      "<hello>em",
 			width:       "<world%>em",
-			elementType: ELEMENT_LINK,
+			elementType: elementLink,
 		},
 	},
 }
@@ -173,7 +173,7 @@ var asHTMLCases = []struct {
 	{
 		"inline image (simple)",
 		element{
-			elementType: ELEMENT_ITERM_IMAGE,
+			elementType: elementITermImage,
 			url:         "test.png",
 			contentType: "image/png",
 			content:     "AA==",
@@ -182,7 +182,7 @@ var asHTMLCases = []struct {
 	}, {
 		"inline image (HTML minefield)",
 		element{
-			elementType: ELEMENT_ITERM_IMAGE,
+			elementType: elementITermImage,
 			url:         "<script>.pdf",
 			contentType: "application/pdf",
 			content:     "<script>",
@@ -192,12 +192,12 @@ var asHTMLCases = []struct {
 		`<img alt="&lt;script&gt;.pdf" src="data:application/pdf;base64,&lt;script&gt;" width="&lt;&#39;&amp;&#39;&gt;%" height="&lt;&#39;&amp;&#39;&gt;px">`,
 	}, {
 		"external image (simple)",
-		element{elementType: ELEMENT_IMAGE, url: "https://example.com/a.png"},
+		element{elementType: elementImage, url: "https://example.com/a.png"},
 		`<img alt="https://example.com/a.png" src="https://example.com/a.png">`,
 	}, {
 		"external image (HTML minefield)",
 		element{
-			elementType: ELEMENT_IMAGE,
+			elementType: elementImage,
 			url:         "https://example.com/?tag=<script>&a=b",
 			alt:         "<script>'hello & world'</script>",
 			width:       "<'&'>%",
@@ -206,12 +206,12 @@ var asHTMLCases = []struct {
 		`<img alt="&lt;script&gt;&#39;hello &amp; world&#39;&lt;/script&gt;" src="https://example.com/?tag=&lt;script&gt;&amp;a=b" width="&lt;&#39;&amp;&#39;&gt;%" height="&lt;&#39;&amp;&#39;&gt;px">`,
 	}, {
 		"link (simple)",
-		element{elementType: ELEMENT_LINK, url: "https://example.com/"},
+		element{elementType: elementLink, url: "https://example.com/"},
 		`<a href="https://example.com/">https://example.com/</a>`,
 	}, {
 		"link (HTML minefield)",
 		element{
-			elementType: ELEMENT_LINK,
+			elementType: elementLink,
 			url:         "https://example.com/?tag=<script>&a=b",
 			content:     "<script>'hello & world'</script>",
 		},

--- a/fixtures/itermlinks.sh.raw
+++ b/fixtures/itermlinks.sh.raw
@@ -1,0 +1,20 @@
+   1: A reference on ]8;;https://en.wikipedia.org/wiki/ANSI_escape_codes\ANSI escape codes]8;;\
+   2: Some overlapping links:
+   3:                         ]8;;https://google.com/\Goo]8;;https://yahoo.com/\Yahoo!]8;;\gle]8;;\
+   4: Up and down:
+   5:                         ]8;;https://google.com/\Go[Aog[Ble]8;;\
+   6: Down and up:
+   7:                         ]8;;https://google.com/\Go[Bog[Ale]8;;\
+   8:
+   9: Cursor left/right:
+  10:                         ]8;;https://google.com/\Goo[Cgle]8;;\
+  11:                         ]8;;https://google.com/\Goo[Dgle]8;;\
+  12: Overwrite:
+  13:                         ]8;;https://google.com/\Google]8;;\
+  14:                         [AYahoo![B
+  15: Newline?
+  16:                         ]8;;https://google.com/\Goo
+  17:                         gle]8;;\
+  18: Colour!
+  19:                         ]8;;https://google.com/\[34mG[31mo[33mo[34mg[32ml[31me[0m]8;;\
+  20:                         ]8;;https://yahoo.com/\[35mYahoo![0m]8;;\

--- a/fixtures/itermlinks.sh.raw
+++ b/fixtures/itermlinks.sh.raw
@@ -17,4 +17,4 @@
   17:                         gle]8;;\
   18: Colour!
   19:                         ]8;;https://google.com/\[34mG[31mo[33mo[34mg[32ml[31me[0m]8;;\
-  20:                         ]8;;https://yahoo.com/\[35mYahoo![0m]8;;\
+  20:                         [35m]8;;https://yahoo.com/\Yah[0moo!]8;;\

--- a/fixtures/itermlinks.sh.rendered
+++ b/fixtures/itermlinks.sh.rendered
@@ -1,0 +1,20 @@
+   1: A reference on <a href="https://en.wikipedia.org/wiki/ANSI_escape_codes">ANSI escape codes</a>
+   2: Some overlapping links:
+   3:                         <a href="https://google.com/">Goo</a><a href="https://yahoo.com/">Yahoo!</a>gle
+   4: Up and down:              <a href="https://google.com/">og</a>
+   5:                         <a href="https://google.com/">Go</a>  <a href="https://google.com/">le</a>
+   6: Down and up:
+   7:                         <a href="https://google.com/">Go</a>  <a href="https://google.com/">le</a>
+   8:                           <a href="https://google.com/">og</a>
+   9: Cursor left&#47;right:
+  10:                         <a href="https://google.com/">Goo</a> <a href="https://google.com/">gle</a>
+  11:                         <a href="https://google.com/">Gogle</a>
+  12: Overwrite:
+  13:                         Yahoo!
+  14:
+  15: Newline?
+  16:                         <a href="https://google.com/">Goo</a>
+<a href="https://google.com/">  17:                         gle</a>
+  18: Colour!
+  19:                         <a href="https://google.com/"><span class="term-fg34">G</span><span class="term-fg31">o</span><span class="term-fg33">o</span><span class="term-fg34">g</span><span class="term-fg32">l</span><span class="term-fg31">e</span></a>
+  20:                         <a href="https://yahoo.com/"><span class="term-fg35">Yahoo!</span></a>

--- a/fixtures/itermlinks.sh.rendered
+++ b/fixtures/itermlinks.sh.rendered
@@ -17,4 +17,4 @@
 <a href="https://google.com/">  17:                         gle</a>
   18: Colour!
   19:                         <a href="https://google.com/"><span class="term-fg34">G</span><span class="term-fg31">o</span><span class="term-fg33">o</span><span class="term-fg34">g</span><span class="term-fg32">l</span><span class="term-fg31">e</span></a>
-  20:                         <a href="https://yahoo.com/"><span class="term-fg35">Yahoo!</span></a>
+  20:                         <a href="https://yahoo.com/"><span class="term-fg35">Yah</span>oo!</a>

--- a/output_test.go
+++ b/output_test.go
@@ -1,0 +1,44 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestScreenLineAsHTML_Interleaving(t *testing.T) {
+	// ANSI escapes can come in any order, but it is invalid to interleave HTML
+	// tags.
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "a span /a /span",
+			input: "five \x1b]8;;http://example.com\x1b\\six \x1b[35mseven \x1b]8;;\x1b\\eight\x1b[0m",
+			want:  `five <a href="http://example.com">six <span class="term-fg35">seven </span></a><span class="term-fg35">eight</span>`,
+		},
+		{
+			name:  "span a /span /a",
+			input: "five \x1b[35msix \x1b]8;;http://example.com\x1b\\seven \x1b[0meight\x1b]8;;\x1b\\",
+			want:  `five <span class="term-fg35">six <a href="http://example.com">seven </a></span><a href="http://example.com">eight</a>`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := &Screen{}
+			s.Write([]byte(test.input))
+			if len(s.screen) != 1 {
+				t.Fatalf("len(s.screen) = %d, want 1", len(s.screen))
+			}
+
+			got := s.screen[0].asHTML()
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("s.screen[0].asHTML diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/style.go
+++ b/style.go
@@ -114,7 +114,8 @@ func (s style) asClasses() []string {
 // Add colours to an existing style, returning a new style.
 func (s style) color(colors []string) style {
 	if len(colors) == 1 && (colors[0] == "0" || colors[0] == "") {
-		return 0
+		// s with all normal styles masked out
+		return s &^ styleComparisonMask
 	}
 
 	colorMode := COLOR_NORMAL
@@ -158,7 +159,7 @@ func (s style) color(colors []string) style {
 		switch cc {
 		case 0:
 			// Reset all styles
-			s = 0
+			s &^= styleComparisonMask
 		case 1:
 			s.setBold(true)
 			s.setFaint(false)

--- a/style.go
+++ b/style.go
@@ -5,8 +5,8 @@ import "strconv"
 type style uint32
 
 // style encoding:
-// 0...  ...7  8... ...15  16...23     24    25....31
-// [fg color]  [bg color]  [flags]  element  [unused]
+// 0...  ...7  8... ...15  16...23     24     25   26....31
+// [fg color]  [bg color]  [flags]  element  link  [unused]
 // flags = bold, faint, etc
 
 const (
@@ -18,11 +18,12 @@ const (
 	sbUnderline
 	sbStrike
 	sbBlink
-	sbElement // meaning: this node is actually an element
+	sbElement   // meaning: this node is actually an element
+	sbHyperlink // this node is styled with an OSC 8 (iTerm-style) link
 )
 
-// Used for comparing styles - ignores the element bit.
-const styleComparisonMask = 0xffffff
+// Used for comparing styles - ignores the element bit, link bit, and unused bits.
+const styleComparisonMask = 0x00ffffff
 
 // isPlain reports if there is no style information. elements (that have no
 // other style set) are also considered plain.
@@ -39,6 +40,7 @@ func (s style) underline() bool { return s&sbUnderline != 0 }
 func (s style) strike() bool    { return s&sbStrike != 0 }
 func (s style) blink() bool     { return s&sbBlink != 0 }
 func (s style) element() bool   { return s&sbElement != 0 }
+func (s style) hyperlink() bool { return s&sbHyperlink != 0 }
 
 func (s *style) setFGColor(v uint8)  { *s = (*s &^ 0xff) | style(v) }
 func (s *style) setBGColor(v uint8)  { *s = (*s &^ 0xff_00) | (style(v) << 8) }
@@ -51,6 +53,7 @@ func (s *style) setUnderline(v bool) { *s = (*s &^ sbUnderline) | booln(v, sbUnd
 func (s *style) setStrike(v bool)    { *s = (*s &^ sbStrike) | booln(v, sbStrike) }
 func (s *style) setBlink(v bool)     { *s = (*s &^ sbBlink) | booln(v, sbBlink) }
 func (s *style) setElement(v bool)   { *s = (*s &^ sbElement) | booln(v, sbElement) }
+func (s *style) setHyperlink(v bool) { *s = (*s &^ sbHyperlink) | booln(v, sbHyperlink) }
 
 const (
 	COLOR_NORMAL        = iota


### PR DESCRIPTION
Fixes #58 and #116 by adding support for OSC 8 sequences.

### Background

terminal-to-html emulates a terminal screen consisting of `screenLine`s, each of which has various runes on it in `node`s. Each node contains the rune at that location and its style. terminal-to-html also has an element model, where some nodes can be elements instead of runes. This was used to implement iTerm style inline images, and a different link sequence (OSC 1339 ...) where the URL and link content are specified with key=value pairs inside a single escape sequence.

OSC 8 links work a bit differently to OSC 1339 links. OSC 8 links function a bit more like anchor tags in HTML: `ESC ]8;;url ST` starts a link like `<a href="url">`, and `ESC ]8;; ST` ends a link like `</a>`. This suggests an implementation where we directly translate OSC 8 sequences to HTML. 

Unfortunately translating OSC 8 sequences to `<a>` ... `</a>` directly doesn't translate well to our model. 

Naïvely, if we store an `<a>` opening tag as an `element`, it would occupy an entire `node`. Similarly with the closing tag. This would expand each link on either side by a space.

Nodes could be made capable of storing both elements and runes. This would negate some of the work I did on memory usage, but that cost is probably acceptable after the streaming work.

Either way introduces some interesting edge cases with some of the other escape sequences, particularly cursor movement. If an `<a>` tag is opened on one line, and before it is closed, the cursor is moved up one line before closing, then the `</a>` would appear in the output before the `<a>`! If we want to prohibit cursor movement within OSC 8 pairs, then we would need another parser mode, and expand the parser to be able to return to a previous mode (e.g. with a stack) rather than directly to "normal".

### Research

What does iTerm2 do? Fortunately we don't need to dig around in its source, we can just `cat` a test file in an iTerm2 window and find out.

<img width="777" alt="Screenshot 2024-07-04 at 1 45 40 PM" src="https://github.com/buildkite/terminal-to-html/assets/2398124/afcaa606-85e4-43e6-9153-2998b7d62aec">

So it appears iTerm2 treats OSC 8 like a _style_: `ESC ]8;;url ST` starts painting the following text as a hyperlink to the URL, and `ESC ]8;; ST` stops painting the text that way. The style then follows the text wherever it is written.

### Implementation

Firstly, along with the cursor position and current style, the screen now also stores the "current URL" as `urlBrush` (like a "link paintbrush"). If it's not empty, that is the URL of the link that will be applied to the text being written, and if it's empty then the text being written won't be linked.

We don't have space in the `style uint32` to store a URL, or even an index into a slice of URLs (with 7 bits left, we could index 128, which is probably plenty, but is an arbitrary-seeming limitation). But most text won't be a link. This suggests storing URLs for links in a sparse data structure based on the coordinate of the node. A `map` fits the bill.

The most complex part is now generating `<a>`...`</a>` pairs while also generating style `<span>`...`</span>` pairs.

We can skip doing a lot of map lookups by using a single style bit to indicate the presence of a link. Since most lines won't have any links, this could be a premature optimisation, but I think it makes some of the code nicer.