### PR TITLE
Replace processing instruction with semantic element

### DIFF
--- a/fixtures/playwright.sh.rendered
+++ b/fixtures/playwright.sh.rendered
@@ -1,19 +1,19 @@
 $ npx playwright test --config=app&#47;tests&#47;e2e&#47;config&#47;playwright.config.prod.ts --project=chromium -g c1
-<?bk t="1706575117741"?>Starting the run with 8 tests
-<?bk t="1706575117741"?>
-<?bk t="1706575117741"?>Running 8 tests using 1 worker, shard 1 of 2
-<?bk t="1706575117741"?>
-<?bk t="1706575129980"?>  ✓  1 [chromium] › c1&#47;default&#47;checkout.spec.ts:3:5 › checkout default flow (11.7s)
-<?bk t="1706575144169"?>  ✓  2 [chromium] › c1&#47;default&#47;checkout.spec.ts:40:5 › checkout default flow with phone number (14.2s)
-<?bk t="1706575156277"?>  ✓  3 [chromium] › c1&#47;default&#47;checkout.spec.ts:77:5 › checkout default flow with digital product (12.1s)
-<?bk t="1706575165823"?>  ✓  4 [chromium] › c1&#47;default&#47;checkout.spec.ts:109:5 › checkout default flow with free digital product (9.5s)
-<?bk t="1706575177303"?>  ✓  5 [chromium] › c1&#47;default&#47;checkout.spec.ts:133:5 › checkout default flow with free physical product (11.6s)
-<?bk t="1706575193194"?>  ✓  6 [chromium] › c1&#47;default&#47;checkout.spec.ts:162:5 › checkout default flow with a manual payment (15.9s)
-<?bk t="1706575205691"?>  ✓  7 [chromium] › c1&#47;default&#47;checkout.spec.ts:197:5 › checkout default flow with a custom payment (12.5s)
-<?bk t="1706575205691"?>  -  8 [chromium] › c1&#47;default&#47;duplicate-tabs.spec.ts:4:6 › checkout with duplicate tabs
-<?bk t="1706575205691"?>Finished test run: passed
-<?bk t="1706575205958"?>
-<?bk t="1706575205958"?>  1 skipped
-<?bk t="1706575205958"?>  7 passed (1.6m)
-<?bk t="1706575205978"?>
+<time datetime="2024-01-30T00:38:37.741Z">2024-01-30T00:38:37.741Z</time>Starting the run with 8 tests
+<time datetime="2024-01-30T00:38:37.741Z">2024-01-30T00:38:37.741Z</time>
+<time datetime="2024-01-30T00:38:37.741Z">2024-01-30T00:38:37.741Z</time>Running 8 tests using 1 worker, shard 1 of 2
+<time datetime="2024-01-30T00:38:37.741Z">2024-01-30T00:38:37.741Z</time>
+<time datetime="2024-01-30T00:38:49.98Z">2024-01-30T00:38:49.98Z</time>  ✓  1 [chromium] › c1&#47;default&#47;checkout.spec.ts:3:5 › checkout default flow (11.7s)
+<time datetime="2024-01-30T00:39:04.169Z">2024-01-30T00:39:04.169Z</time>  ✓  2 [chromium] › c1&#47;default&#47;checkout.spec.ts:40:5 › checkout default flow with phone number (14.2s)
+<time datetime="2024-01-30T00:39:16.277Z">2024-01-30T00:39:16.277Z</time>  ✓  3 [chromium] › c1&#47;default&#47;checkout.spec.ts:77:5 › checkout default flow with digital product (12.1s)
+<time datetime="2024-01-30T00:39:25.823Z">2024-01-30T00:39:25.823Z</time>  ✓  4 [chromium] › c1&#47;default&#47;checkout.spec.ts:109:5 › checkout default flow with free digital product (9.5s)
+<time datetime="2024-01-30T00:39:37.303Z">2024-01-30T00:39:37.303Z</time>  ✓  5 [chromium] › c1&#47;default&#47;checkout.spec.ts:133:5 › checkout default flow with free physical product (11.6s)
+<time datetime="2024-01-30T00:39:53.194Z">2024-01-30T00:39:53.194Z</time>  ✓  6 [chromium] › c1&#47;default&#47;checkout.spec.ts:162:5 › checkout default flow with a manual payment (15.9s)
+<time datetime="2024-01-30T00:40:05.691Z">2024-01-30T00:40:05.691Z</time>  ✓  7 [chromium] › c1&#47;default&#47;checkout.spec.ts:197:5 › checkout default flow with a custom payment (12.5s)
+<time datetime="2024-01-30T00:40:05.691Z">2024-01-30T00:40:05.691Z</time>  -  8 [chromium] › c1&#47;default&#47;duplicate-tabs.spec.ts:4:6 › checkout with duplicate tabs
+<time datetime="2024-01-30T00:40:05.691Z">2024-01-30T00:40:05.691Z</time>Finished test run: passed
+<time datetime="2024-01-30T00:40:05.958Z">2024-01-30T00:40:05.958Z</time>
+<time datetime="2024-01-30T00:40:05.958Z">2024-01-30T00:40:05.958Z</time>  1 skipped
+<time datetime="2024-01-30T00:40:05.958Z">2024-01-30T00:40:05.958Z</time>  7 passed (1.6m)
+<time datetime="2024-01-30T00:40:05.978Z">2024-01-30T00:40:05.978Z</time>
 Done in 96.34s.

--- a/internal/assets/terminal.css
+++ b/internal/assets/terminal.css
@@ -13,6 +13,8 @@
 
 .term-container img { max-width: 100%; }
 
+.term-container time { padding-right: 1ex; }
+
 .term a { color: inherit; text-decoration: underline; text-decoration-style: dashed; }
 .term a:hover { color: #2882F9 }
 

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -310,25 +310,17 @@ var rendererTestCases = []struct {
 		"\x1b]8;;artifact://hello.txt\x07the hello.txt artifact\x1b]8;;\x07\n",
 		`<a href="artifact://hello.txt">the hello.txt artifact</a>`,
 	}, {
-		`renders bk APC escapes as processing instructions`,
-		"\x1b_bk;x=llamas\\;;y=alpacas\x07",
-		`<?bk x="llamas;" y="alpacas"?>`,
-	}, {
-		`renders bk APC escapes as processing instructions`,
-		"\x1b" + `_bk;a='1 ("one")';b="2 ('two')"` + "\x07",
-		`<?bk a="1 (&#34;one&#34;)" b="2 (&#39;two&#39;)"?>`,
-	}, {
 		`renders bk APC escapes followed by text`,
 		"\x1b_bk;t=123\x07hello",
-		`<?bk t="123"?>hello`,
+		`<time datetime="1970-01-01T00:00:00.123Z">1970-01-01T00:00:00.123Z</time>hello`,
 	}, {
 		`handles bk APC escapes surrounded by text`,
 		"hello \x1b_bk;t=123\x07world",
-		`<?bk t="123"?>hello world`,
+		`<time datetime="1970-01-01T00:00:00.123Z">1970-01-01T00:00:00.123Z</time>hello world`,
 	}, {
 		`prefixes lines with the last timestamp seen`,
 		"hello\x1b_bk;t=123\x07 world\x1b_bk;t=456\x07!",
-		`<?bk t="456"?>hello world!`,
+		`<time datetime="1970-01-01T00:00:00.456Z">1970-01-01T00:00:00.456Z</time>hello world!`,
 	}, {
 		`handles timestamps across multiple lines`,
 		strings.Join([]string{
@@ -336,8 +328,8 @@ var rendererTestCases = []struct {
 			"another\x1b_bk;t=345\x07 line\x1b_bk;t=456\x07!",
 		}, "\n"),
 		strings.Join([]string{
-			`<?bk t="234"?>hello world!`,
-			`<?bk t="456"?>another line!`,
+			`<time datetime="1970-01-01T00:00:00.234Z">1970-01-01T00:00:00.234Z</time>hello world!`,
+			`<time datetime="1970-01-01T00:00:00.456Z">1970-01-01T00:00:00.456Z</time>another line!`,
 		}, "\n"),
 	}, {
 		`handles timestamps and delta timestamps`,
@@ -346,8 +338,8 @@ var rendererTestCases = []struct {
 			"another\x1b_bk;dt=111\x07 line\x1b_bk;dt=111\x07!",
 		}, "\n"),
 		strings.Join([]string{
-			`<?bk t="234"?>hello world!`,
-			`<?bk t="456"?>another line!`,
+			`<time datetime="1970-01-01T00:00:00.234Z">1970-01-01T00:00:00.234Z</time>hello world!`,
+			`<time datetime="1970-01-01T00:00:00.456Z">1970-01-01T00:00:00.456Z</time>another line!`,
 		}, "\n"),
 	},
 }


### PR DESCRIPTION
### What
Stop outputting `<?bk ... ?>`, start outputting `<time datetime="..."></time>`.

### Why
`<?bk ... ?>` is a bit weird. It's not a real HTML tag, if anything it's an SGML or XML "processing instruction". It tends to disappear when browsed or passed through any reasonable HTML parser or sanitiser, and it typically requires workarounds to handle.

In practice we only use it as a container for the log line timestamp. There's a more semantic element: `<time>`. Unfortunately we can't just shove a millisecond epoch into it, but formatting timestamps is easy in Go.

What about other metadata "namespaces" and "keys"? The parser drops any APC in a "namespace" other than "bk". It also performs the arithmetic to convert `dt` into `t` (and `dt` isn't used by the agent yet). Future compatibility isn't closed off by this change: if we want to implement some new metadata key in buildkite.com, we'd be upgrading terminal-to-html anyway. But it does effectively remove unsupported metadata keys from the produced output.