### PR TITLE
Bump version to v3.15.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.14.0"
+var baseVersion string = "3.15.0"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.15.0](https://github.com/buildkite/terminal-to-html/tree/v3.15.0) (2024-08-29)
[Full Changelog](https://github.com/buildkite/terminal-to-html/compare/v3.14.0...v3.15.0)

> [!NOTE]
> If you run terminal-to-html on Buildkite agent logs yourself, be aware that the output format of log line timestamps is changing! 
> Instead of `<?bk t="1724909269123"?>`, you will get a more convenient `<time datetime="2024-08-29T05:27:49.123Z">2024-08-29T05:27:49.123Z</time>`. This will also cause timestamps to be visible in HTML output without any further processing.

### Changes
- Replace processing instruction with semantic element [#175](https://github.com/buildkite/terminal-to-html/pull/175) (@DrJosh9000)
- Add sanitiser warning to readme [#174](https://github.com/buildkite/terminal-to-html/pull/174) (@DrJosh9000)

### Dependencies
- Bump docker/library/golang from 1.22.6 to 1.23.0 [#173](https://github.com/buildkite/terminal-to-html/pull/173) (@dependabot[bot])
- Bump github.com/urfave/cli/v2 from 2.27.3 to 2.27.4 [#171](https://github.com/buildkite/terminal-to-html/pull/171) (@dependabot[bot])
- Bump golang.org/x/sys from 0.23.0 to 0.24.0 [#172](https://github.com/buildkite/terminal-to-html/pull/172) (@dependabot[bot])
- Bump docker/library/golang from 1.22.5 to 1.22.6 [#170](https://github.com/buildkite/terminal-to-html/pull/170) (@dependabot[bot])
- Bump docker/library/golang from `fcae9e0` to `829eff9` [#167](https://github.com/buildkite/terminal-to-html/pull/167) (@dependabot[bot])
- Bump golang.org/x/sys from 0.22.0 to 0.23.0 [#169](https://github.com/buildkite/terminal-to-html/pull/169) (@dependabot[bot])
- Bump golang.org/x/sys from 0.21.0 to 0.22.0 [#165](https://github.com/buildkite/terminal-to-html/pull/165) (@dependabot[bot])
- Bump github.com/urfave/cli/v2 from 2.27.2 to 2.27.3 [#168](https://github.com/buildkite/terminal-to-html/pull/168) (@dependabot[bot])
- Bump docker/library/golang from `45c516d` to `fcae9e0` [#166](https://github.com/buildkite/terminal-to-html/pull/166) (@dependabot[bot])