### PR TITLE
Teach terminal-to-html about numbers bigger than 127

### DIFF
--- a/output_test.go
+++ b/output_test.go
@@ -29,7 +29,10 @@ func TestScreenLineAsHTML_Interleaving(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := &Screen{}
+			s, err := NewScreen()
+			if err != nil {
+				t.Fatalf("NewScreen() = %v", err)
+			}
 			s.Write([]byte(test.input))
 			if len(s.screen) != 1 {
 				t.Fatalf("len(s.screen) = %d, want 1", len(s.screen))

--- a/parser.go
+++ b/parser.go
@@ -199,7 +199,7 @@ func (p *parser) processOperatingSystemCommand(end int) {
 		if p.screen.x != 0 {
 			p.screen.newLine()
 		}
-		p.screen.clear(p.screen.y, screenStartOfLine, screenEndOfLine)
+		p.screen.currentLine().clear(screenStartOfLine, screenEndOfLine)
 	}
 
 	if err != nil {
@@ -298,16 +298,20 @@ func (p *parser) handleControlSequence(char rune) {
 	switch char {
 	case '?', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 		// Part of an instruction
+
 	case ';':
 		p.addInstruction()
 		p.instructionStartedAt = p.cursor + utf8.RuneLen(';')
-	case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'J', 'K', 'M', 'Q':
+
+	case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'M', 'Q':
 		p.addInstruction()
 		p.screen.applyEscape(char, p.instructions)
 		p.mode = parserModeNormal
-	case 'H', 'L':
+
+	case 'L':
 		// Set/reset mode (SM/RM), ignore and continue
 		p.mode = parserModeNormal
+
 	default:
 		// unrecognized character, abort the escapeCode
 		p.cursor = p.escapeStartedAt

--- a/parser_test.go
+++ b/parser_test.go
@@ -8,70 +8,70 @@ import (
 )
 
 func TestParseSimpleXY(t *testing.T) {
-	s := parsedScreen("hello")
-	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+	s := parsedScreen(t, "hello")
+	if err := assertTextXY(s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestParseAfterCursorMovement(t *testing.T) {
-	s := parsedScreen("hello\x1b[4D!")
-	if err := assertTextXY(t, s, "h!llo", 2, 0); err != nil {
+	s := parsedScreen(t, "hello\x1b[4D!")
+	if err := assertTextXY(s, "h!llo", 2, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestParseAfterOverwriteAndClearToEndOfLine(t *testing.T) {
-	s := parsedScreen("hello\x1b[4Di!\x1b[0K")
-	if err := assertTextXY(t, s, "hi!", 3, 0); err != nil {
+	s := parsedScreen(t, "hello\x1b[4Di!\x1b[0K")
+	if err := assertTextXY(s, "hi!", 3, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 // Application Program Command should be zero-width
 func TestParseZeroWidthAPC(t *testing.T) {
-	s := parsedScreen("\x1b_bk;t=0\x07")
-	if err := assertTextXY(t, s, "", 0, 0); err != nil {
+	s := parsedScreen(t, "\x1b_bk;t=0\x07")
+	if err := assertTextXY(s, "", 0, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 // Application Program Command can be followed by normal text
 func TestParseAPCPrefix(t *testing.T) {
-	s := parsedScreen("\x1b_bk;t=0\x07hello")
-	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+	s := parsedScreen(t, "\x1b_bk;t=0\x07hello")
+	if err := assertTextXY(s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 // Application Program Command can be terminated with ESC \
 func TestParseAPCWithSTPrefix(t *testing.T) {
-	s := parsedScreen("\x1b_bk;t=0\x1b\\hello")
-	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+	s := parsedScreen(t, "\x1b_bk;t=0\x1b\\hello")
+	if err := assertTextXY(s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 // Application Program Command should be zero-width for cursor movement
 func TestParseXYAfterCursorMovementThroughBuildkiteTimestampAPC(t *testing.T) {
-	s := parsedScreen("hel\x1b_bk;t=0\x07lo\x1b[4D3")
-	if err := assertTextXY(t, s, "h3llo", 2, 0); err != nil {
+	s := parsedScreen(t, "hel\x1b_bk;t=0\x07lo\x1b[4D3")
+	if err := assertTextXY(s, "h3llo", 2, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 // Operating System Command can be terminated with BEL
 func TestParseOSCHyperlink(t *testing.T) {
-	s := parsedScreen("\x1b]8;;http://example.com/\x07hello")
-	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+	s := parsedScreen(t, "\x1b]8;;http://example.com/\x07hello")
+	if err := assertTextXY(s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 // Operating System Command can be terminated with ESC \
 func TestParseOSCWithST(t *testing.T) {
-	s := parsedScreen("\x1b]8;;http://example.com/\x1b\\hello")
-	if err := assertTextXY(t, s, "hello", 5, 0); err != nil {
+	s := parsedScreen(t, "\x1b]8;;http://example.com/\x1b\\hello")
+	if err := assertTextXY(s, "hello", 5, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -81,18 +81,21 @@ func TestParseDECCursorSaveRestore(t *testing.T) {
 	decrc := "\x1b8"
 	moveUpAndClearLine := csi(2, "A") + csi(2, "K") + csi(1, "G")
 
-	s := parsedScreen("one\ntwo\nthree\n" + decsc + moveUpAndClearLine + "overwrite\n" + decrc + "four\n")
+	s := parsedScreen(t, "one\ntwo\nthree\n"+decsc+moveUpAndClearLine+"overwrite\n"+decrc+"four\n")
 
 	expected := strings.Join([]string{"one", "overwrite", "three", "four"}, "\n")
-	if err := assertTextXY(t, s, expected, 0, 4); err != nil {
+	if err := assertTextXY(s, expected, 0, 4); err != nil {
 		t.Error(err)
 	}
 }
 
 // ----------------------------------------
 
-func parsedScreen(data string) *Screen {
-	s := &Screen{}
+func parsedScreen(t *testing.T, data string) *Screen {
+	s, err := NewScreen()
+	if err != nil {
+		t.Fatalf("NewScreen error: %v", err)
+	}
 	s.Write([]byte(data))
 	return s
 }
@@ -103,7 +106,7 @@ func csi(n int, code string) string {
 	return "\x1b[" + strconv.Itoa(n) + code
 }
 
-func assertXY(t *testing.T, s *Screen, x, y int) error {
+func assertXY(s *Screen, x, y int) error {
 	if s.x != x {
 		return fmt.Errorf("expected screen.x == %d, got %d", x, s.x)
 	}
@@ -113,18 +116,18 @@ func assertXY(t *testing.T, s *Screen, x, y int) error {
 	return nil
 }
 
-func assertText(t *testing.T, s *Screen, expected string) error {
+func assertText(s *Screen, expected string) error {
 	if actual := s.AsPlainText(); actual != expected {
 		return fmt.Errorf("expected text %q, got %q", expected, actual)
 	}
 	return nil
 }
 
-func assertTextXY(t *testing.T, s *Screen, expected string, x, y int) error {
-	if err := assertXY(t, s, x, y); err != nil {
+func assertTextXY(s *Screen, expected string, x, y int) error {
+	if err := assertXY(s, x, y); err != nil {
 		return err
 	}
-	if err := assertText(t, s, expected); err != nil {
+	if err := assertText(s, expected); err != nil {
 		return err
 	}
 	return nil

--- a/screen.go
+++ b/screen.go
@@ -1,14 +1,20 @@
 package terminal
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
 )
 
-// A terminal 'screen'. Current cursor position, cursor style, and characters
+const (
+	screenStartOfLine = 0
+	screenEndOfLine   = math.MaxInt
+)
+
+// A terminal 'screen'. Tracks cursor position, cursor style, content, size...
 type Screen struct {
-	// Current cursor position
+	// Current cursor position on the screen
 	x, y int
 
 	// Screen contents
@@ -21,11 +27,23 @@ type Screen struct {
 	urlBrush string
 
 	// Parser to use for streaming processing
-	parser *parser
+	parser parser
 
 	// Optional maximum amount of backscroll to retain in the buffer.
+	// Also sets an upper bound on window height.
 	// Setting to 0 or negative makes the screen buffer unlimited.
-	MaxLines int
+	maxLines int
+
+	// Optional upper bound on window width.
+	// Setting to 0 or negative doesn't enforce a limit.
+	maxColumns int
+
+	// Current window size. This is required to properly bound cursor movement
+	// commands. It defaults to 160 columns * 100 lines.
+	// Note that window size does not bound content - maxLines controls the
+	// number of screen lines held in the buffer, and each line can be
+	// arbitrarily long (when written with plain text).
+	cols, lines int
 
 	// Optional callback. If not nil, as each line is scrolled out of the top of
 	// the buffer, this func is called with the HTML.
@@ -34,73 +52,81 @@ type Screen struct {
 	// Processing statistics
 	LinesScrolledOut int // count of lines that scrolled off the top
 	CursorUpOOB      int // count of times ESC [A or ESC [F tried to move y < 0
+	CursorDownOOB    int // count of times ESC [B or ESC [G tried to move y >= height
+	CursorFwdOOB     int // count of times ESC [C tried to move x >= width
 	CursorBackOOB    int // count of times ESC [D tried to move x < 0
 }
 
-type screenLine struct {
-	nodes []node
+// ScreenOption is a functional option for creating new screens.
+type ScreenOption = func(*Screen) error
 
-	// metadata is { namespace => { key => value, ... }, ... }
-	// e.g. { "bk" => { "t" => "1234" } }
-	metadata map[string]map[string]string
-
-	// element nodes refer to elements in this slice by index
-	// (if node.style.element(), then elements[node.blob] is the element)
-	elements []*element
-
-	// hyperlinks stores the URL targets for OSC 8 (iTerm-style) links
-	// by X position. URLs are too big to fit in every node, most lines won't
-	// have links and most nodes in a line won't be linked.
-	// So a map is used for sparse storage, only lazily created when text with
-	// a link style is written.
-	hyperlinks map[int]string
+// WithSize sets the initial window size.
+func WithSize(w, h int) ScreenOption {
+	return func(s *Screen) error { return s.SetSize(w, h) }
 }
 
-const (
-	screenStartOfLine = 0
-	screenEndOfLine   = math.MaxInt
-)
-
-// Clear part (or all) of a line on the screen. The range to clear is inclusive
-// of xStart and xEnd.
-func (s *Screen) clear(y, xStart, xEnd int) {
-	if y < 0 || y >= len(s.screen) {
-		return
-	}
-
-	if xStart < 0 {
-		xStart = 0
-	}
-	if xEnd < xStart {
-		// Not a valid range.
-		return
-	}
-
-	line := &s.screen[y]
-
-	if xStart >= len(line.nodes) {
-		// Clearing part of a line starting after the end of the current line...
-		return
-	}
-
-	if xEnd >= len(line.nodes)-1 {
-		// Clear from start to end of the line
-		line.nodes = line.nodes[:xStart]
-		return
-	}
-
-	for i := xStart; i <= xEnd; i++ {
-		line.nodes[i] = emptyNode
+// WithMaxSize sets the screen size limits.
+func WithMaxSize(maxCols, maxLines int) ScreenOption {
+	return func(s *Screen) error {
+		s.maxColumns, s.maxLines = maxCols, maxLines
+		// Ensure the size fits within the new limits.
+		if maxCols > 0 {
+			s.cols = min(s.cols, maxCols)
+		}
+		if maxLines > 0 {
+			s.lines = min(s.lines, maxLines)
+		}
+		return nil
 	}
 }
 
-// "Safe" parseint for parsing ANSI instructions
+// NewScreen creates a new screen with various options.
+func NewScreen(opts ...ScreenOption) (*Screen, error) {
+	s := &Screen{
+		// Arbitrarily chosen size, but 160 is double the traditional terminal
+		// width (80) and 100 is 4x the traditional terminal height (25).
+		// 160x100 also matches the buildkite-agent PTY size.
+		cols:  160,
+		lines: 100,
+		parser: parser{
+			mode: parserModeNormal,
+		},
+	}
+	s.parser.screen = s
+	for _, o := range opts {
+		if err := o(s); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// SetSize changes the window size.
+func (s *Screen) SetSize(cols, lines int) error {
+	if cols <= 0 || lines <= 0 {
+		return fmt.Errorf("negative dimension in size %dw x %dh", cols, lines)
+	}
+	if s.maxColumns > 0 && cols > s.maxColumns {
+		return fmt.Errorf("cols greater than max [%d > %d]", cols, s.maxColumns)
+	}
+	if s.maxLines > 0 && lines > s.maxLines {
+		return fmt.Errorf("lines greater than max [%d > %d]", lines, s.maxLines)
+	}
+	s.cols, s.lines = cols, lines
+	return nil
+}
+
+// ansiInt parses s as a decimal integer. If s is empty or malformed, it
+// returns 1.
 func ansiInt(s string) int {
 	if s == "" {
 		return 1
 	}
-	i, _ := strconv.ParseInt(s, 10, 8)
-	return int(i)
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 1
+	}
+	return i
 }
 
 // Move the cursor up, if we can
@@ -110,19 +136,34 @@ func (s *Screen) up(i string) {
 		s.CursorUpOOB++
 		s.y = 0
 	}
+	// If the cursor was on a line longer than the screen width, then pretend
+	// the line wrapped at that width.
+	// This is consistent with iTerm2 - try printing a long line of text,
+	// then ESC [1B, then some more text... then resize the window and see what
+	// happens.
+	s.x = s.x % s.cols
 }
 
-// Move the cursor down
+// Move the cursor down, if we can
 func (s *Screen) down(i string) {
 	s.y += ansiInt(i)
+	if s.y >= s.lines {
+		s.CursorDownOOB++
+		s.y = s.lines - 1
+	}
+	s.x = s.x % s.cols // see coment in the up method.
 }
 
-// Move the cursor forward on the line
+// Move the cursor forward (right) on the line, if we can
 func (s *Screen) forward(i string) {
 	s.x += ansiInt(i)
+	if s.x >= s.cols {
+		s.CursorFwdOOB++
+		s.x = s.cols - 1
+	}
 }
 
-// Move the cursor backward, if we can
+// Move the cursor backward (left), if we can
 func (s *Screen) backward(i string) {
 	s.x -= ansiInt(i)
 	if s.x < 0 {
@@ -131,22 +172,48 @@ func (s *Screen) backward(i string) {
 	}
 }
 
-func (s *Screen) getCurrentLineForWriting() *screenLine {
-	// Ensure there are enough lines on screen for the cursor's Y position.
-	for s.y >= len(s.screen) {
-		// If MaxLines is not in use, or adding a new line would not make it
-		// larger than MaxLines, then just allocate a new line.
-		if s.MaxLines <= 0 || len(s.screen)+1 <= s.MaxLines {
-			// nodes is preallocated with space for 80 columns, which is
-			// arbitrary, but also the traditional terminal width.
-			newLine := screenLine{nodes: make([]node, 0, 80)}
+// top returns the index within s.screen where the window begins.
+// The top of the window is not necessarily the top of the buffer: in fact,
+// the window is always the bottom-most s.lines (or fewer) elements of s.screen.
+// top + s.y = the index of the line where the cursor is.
+func (s *Screen) top() int {
+	return max(0, len(s.screen)-s.lines)
+}
+
+// currentLine returns the line the cursor is on, or nil if no such line has
+// been added to the screen buffer yet.
+func (s *Screen) currentLine() *screenLine {
+	yidx := s.top() + s.y
+	if yidx < 0 || yidx >= len(s.screen) {
+		return nil
+	}
+	return &s.screen[yidx]
+}
+
+// currentLineForWriting returns the line the cursor is on, or if there is no
+// line allocated in the buffer yet, allocates a new line and ensures it has
+// enough nodes to write something at the cursor position.
+func (s *Screen) currentLineForWriting() *screenLine {
+	// Ensure there are enough lines on screen to start writing here.
+	for s.currentLine() == nil {
+		// If maxLines is not in use, or adding a new line would not make it
+		// larger than maxLines, then just allocate a new line.
+		if s.maxLines <= 0 || len(s.screen)+1 <= s.maxLines {
+			newLine := screenLine{nodes: make([]node, 0, s.cols)}
 			s.screen = append(s.screen, newLine)
+			if s.y >= s.lines {
+				// Because the "window" is always the last s.lines of s.screen
+				// (or all of them, if there are fewer lines than s.lines)
+				// appending a new line shifts the window down. In that case,
+				// compensate by shifting s.y up (eventually to within bounds).
+				s.y--
+			}
 			continue
 		}
 
-		// MaxLines is in effect, and adding a new line would make the screen
-		// larger than MaxLines.
-		// Pass the line being scrolled out to ScrollOutFunc if it exists.
+		// maxLines is in effect, and adding a new line would make the screen
+		// larger than maxLines.
+		// Pass the line being scrolled out to scrollOutFunc, if not nil.
 		if s.ScrollOutFunc != nil {
 			s.ScrollOutFunc(s.screen[0].asHTML())
 		}
@@ -156,10 +223,13 @@ func (s *Screen) getCurrentLineForWriting() *screenLine {
 		// Recycle its nodes slice to make a new line on the bottom.
 		newLine := screenLine{nodes: s.screen[0].nodes[:0]}
 		s.screen = append(s.screen[1:], newLine)
+
+		// Since the buffer scrolled down, leaving len(s.screen) unchanged,
+		// s.y moves upwards.
 		s.y--
 	}
 
-	line := &s.screen[s.y]
+	line := s.currentLine()
 
 	// Add columns if currently shorter than the cursor's x position
 	for i := len(line.nodes); i <= s.x; i++ {
@@ -170,7 +240,7 @@ func (s *Screen) getCurrentLineForWriting() *screenLine {
 
 // Write a character to the screen's current X&Y, along with the current screen style
 func (s *Screen) write(data rune) {
-	line := s.getCurrentLineForWriting()
+	line := s.currentLineForWriting()
 	line.nodes[s.x] = node{blob: data, style: s.style}
 
 	// OSC 8 links work like a style.
@@ -196,7 +266,7 @@ func (s *Screen) appendMany(data []rune) {
 }
 
 func (s *Screen) appendElement(i *element) {
-	line := s.getCurrentLineForWriting()
+	line := s.currentLineForWriting()
 	idx := len(line.elements)
 	line.elements = append(line.elements, i)
 	ns := s.style
@@ -208,7 +278,7 @@ func (s *Screen) appendElement(i *element) {
 // Set line metadata. Merges the provided data into any existing
 // metadata for the current line, overwriting data when keys collide.
 func (s *Screen) setLineMetadata(namespace string, data map[string]string) {
-	line := s.getCurrentLineForWriting()
+	line := s.currentLineForWriting()
 	if line.metadata == nil {
 		line.metadata = map[string]map[string]string{
 			namespace: data,
@@ -236,73 +306,98 @@ func (s *Screen) color(i []string) {
 
 // Apply an escape sequence to the screen
 func (s *Screen) applyEscape(code rune, instructions []string) {
-	if len(instructions) == 0 {
-		// Ensure we always have a first instruction
-		instructions = []string{""}
+	// Wrap slice accesses in a bounds check. Instructions not supplied default
+	// to the empty string.
+	inst := func(i int) string {
+		if i < 0 || i >= len(instructions) {
+			return ""
+		}
+		return instructions[i]
 	}
 
 	switch code {
 	case 'A': // Cursor Up: go up n
-		s.up(instructions[0])
+		s.up(inst(0))
 
 	case 'B': // Cursor Down: go down n
-		s.down(instructions[0])
+		s.down(inst(0))
 
 	case 'C': // Cursor Forward: go right n
-		s.forward(instructions[0])
+		s.forward(inst(0))
 
 	case 'D': // Cursor Back: go left n
-		s.backward(instructions[0])
+		s.backward(inst(0))
 
 	case 'E': // Cursor Next Line: Go to beginning of line n down
 		s.x = 0
-		s.down(instructions[0])
+		s.down(inst(0))
 
 	case 'F': // Cursor Previous Line: Go to beginning of line n up
 		s.x = 0
-		s.up(instructions[0])
+		s.up(inst(0))
 
 	case 'G': // Cursor Horizontal Absolute: Go to column n (default 1)
-		s.x = max(0, ansiInt(instructions[0])-1)
+		s.x = ansiInt(inst(0)) - 1
+		s.x = max(s.x, 0)
+		s.x = min(s.x, s.cols-1)
 
-	// NOTE: H (Cursor Position) is not yet implemented
+	case 'H': // Cursor Position Absolute: Go to row n and column m (default 1;1).
+		s.y = ansiInt(inst(0)) - 1
+		s.y = max(s.y, 0)
+		s.y = min(s.y, s.lines-1)
+		s.x = ansiInt(inst(1)) - 1
+		s.x = max(s.x, 0)
+		s.x = min(s.x, s.cols-1)
 
 	case 'J': // Erase in Display: Clears part of the screen.
-		switch instructions[0] {
-		// "erase from current position to end (inclusive)"
-		case "0", "":
-			// This line should be equivalent to K0
-			s.clear(s.y, s.x, screenEndOfLine)
-			// Truncate the screen below the current line
-			if len(s.screen) > s.y {
-				s.screen = s.screen[:s.y+1]
+		switch inst(0) {
+		case "0", "": // "erase from current position to end (inclusive)"
+			s.currentLine().clear(s.x, screenEndOfLine) // same as ESC [0K
+
+			// The window is at the bottom of the screen buffer, so we can clear
+			// the rest of the screen using truncation.
+			yidx := s.top() + s.y
+			if yidx < 0 || yidx >= len(s.screen) {
+				return
 			}
-		// "erase from beginning to current position (inclusive)"
-		case "1":
-			// This line should be equivalent to K1
-			s.clear(s.y, screenStartOfLine, s.x)
-			// Truncate the screen above the current line
-			if len(s.screen) > s.y {
-				s.screen = s.screen[s.y+1:]
+			s.screen = s.screen[:yidx+1]
+
+		case "1": // "erase from beginning to current position (inclusive)"
+			s.currentLine().clear(screenStartOfLine, s.x) // same as ESC [1K
+
+			// real terms erase part of the window, but the cursor stays still.
+			// The intervening lines simply become blank.
+			top := s.top()
+			end := min(top+s.y, len(s.screen))
+			for i := top; i < end; i++ {
+				s.screen[i].clearAll()
 			}
-			// Adjust the cursor position to compensate
-			s.y = 0
-		// 2: "erase entire display", 3: "erase whole display including scroll-back buffer"
-		// Given we don't have a scrollback of our own, we treat these as equivalent
-		case "2", "3":
-			s.screen = nil
-			s.x = 0
-			s.y = 0
+
+		case "2":
+			// 2: "erase entire display"
+			// Previous implementations performed this the same as ESC [3J,
+			// which also removes all "scroll-back".
+			s.screen = s.screen[:s.top()]
+			// Note: on real terminals this doesn't reset the cursor position.
+			s.x, s.y = 0, 0
+
+		case "3":
+			// 3: "erase whole display including scroll-back buffer"
+			s.screen = s.screen[:0]
+			// Note: on real terminals this doesn't reset the cursor position.
+			s.x, s.y = 0, 0
 		}
 
 	case 'K': // Erase in Line: erases part of the line.
-		switch instructions[0] {
+		switch inst(0) {
 		case "0", "":
-			s.clear(s.y, s.x, screenEndOfLine)
+			s.currentLine().clear(s.x, screenEndOfLine)
+
 		case "1":
-			s.clear(s.y, screenStartOfLine, s.x)
+			s.currentLine().clear(screenStartOfLine, s.x)
+
 		case "2":
-			s.clear(s.y, screenStartOfLine, screenEndOfLine)
+			s.currentLine().clearAll()
 		}
 
 	case 'M':
@@ -312,12 +407,6 @@ func (s *Screen) applyEscape(code rune, instructions []string) {
 
 // Write writes ANSI text to the screen.
 func (s *Screen) Write(input []byte) (int, error) {
-	if s.parser == nil {
-		s.parser = &parser{
-			mode:   parserModeNormal,
-			screen: s,
-		}
-	}
 	s.parser.parseToScreen(input)
 	return len(input), nil
 }
@@ -362,5 +451,62 @@ func (s *Screen) carriageReturn() {
 func (s *Screen) backspace() {
 	if s.x > 0 {
 		s.x--
+	}
+}
+
+type screenLine struct {
+	nodes []node
+
+	// metadata is { namespace => { key => value, ... }, ... }
+	// e.g. { "bk" => { "t" => "1234" } }
+	metadata map[string]map[string]string
+
+	// element nodes refer to elements in this slice by index
+	// (if node.style.element(), then elements[node.blob] is the element)
+	elements []*element
+
+	// hyperlinks stores the URL targets for OSC 8 (iTerm-style) links
+	// by X position. URLs are too big to fit in every node, most lines won't
+	// have links and most nodes in a line won't be linked.
+	// So a map is used for sparse storage, only lazily created when text with
+	// a link style is written.
+	hyperlinks map[int]string
+}
+
+func (l *screenLine) clearAll() {
+	if l == nil {
+		return
+	}
+	l.nodes = l.nodes[:0]
+}
+
+// clear clears part (or all) of a line. The range to clear is inclusive
+// of xStart and xEnd.
+func (l *screenLine) clear(xStart, xEnd int) {
+	if l == nil {
+		return
+	}
+
+	if xStart < 0 {
+		xStart = 0
+	}
+	if xEnd < xStart {
+		// Not a valid range.
+		return
+	}
+
+	if xStart >= len(l.nodes) {
+		// Clearing part of a line starting after the end of the current line...
+		return
+	}
+
+	if xEnd >= len(l.nodes)-1 {
+		// Clear from start to end of the line
+		l.nodes = l.nodes[:xStart]
+		return
+	}
+
+	for i := xStart; i <= xEnd; i++ {
+		l.nodes[i] = emptyNode
 	}
 }

--- a/style.go
+++ b/style.go
@@ -113,7 +113,7 @@ func (s style) asClasses() []string {
 
 // Add colours to an existing style, returning a new style.
 func (s style) color(colors []string) style {
-	if len(colors) == 1 && (colors[0] == "0" || colors[0] == "") {
+	if len(colors) == 0 || (len(colors) == 1 && (colors[0] == "0" || colors[0] == "")) {
 		// s with all normal styles masked out
 		return s &^ styleComparisonMask
 	}

--- a/terminal.go
+++ b/terminal.go
@@ -10,9 +10,15 @@ GO111MODULE=on go install github.com/buildkite/terminal-to-html/v3/cmd/terminal-
 */
 package terminal
 
+import "fmt"
+
 // Render converts ANSI to HTML and returns the result.
 func Render(input []byte) string {
-	screen := Screen{}
+	screen, err := NewScreen()
+	if err != nil {
+		// This shouldn't happen! (famous last words)
+		panic(fmt.Sprintf("NewScreen error: %v", err))
+	}
 	screen.Write(input)
 	return screen.AsHTML()
 }

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -24,11 +25,11 @@ var TestFiles = []string{
 	"weather.sh",
 }
 
-func loadFixture(t testing.TB, base string, ext string) []byte {
-	filename := fmt.Sprintf("fixtures/%s.%s", base, ext)
+func loadFixture(t testing.TB, base, ext string) []byte {
+	filename := filepath.Join("fixtures", base+"."+ext)
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		t.Errorf("could not load fixture %s: %v", filename, err)
+		t.Fatalf("could not load fixture %s: %v", filename, err)
 	}
 	return data
 }
@@ -38,60 +39,77 @@ func base64Encode(stringToEncode string) string {
 }
 
 var rendererTestCases = []struct {
-	name     string
-	input    string
-	expected string
+	name  string
+	input string
+	want  string
 }{
 	{
-		`input that ends in a newline will not include that newline`,
-		"hello\n",
-		"hello",
-	}, {
-		`closes colors that get opened`,
-		"he\033[32mllo",
-		"he<span class=\"term-fg32\">llo</span>",
-	}, {
-		`treats multi-byte unicode characters as individual runes`,
-		"€€€€€€\b\b\baaa",
-		"€€€aaa",
-	}, {
-		`skips over colors when backspacing`,
-		"he\x1b[32m\x1b[33m\bllo",
-		"h<span class=\"term-fg33\">llo</span>",
-	}, {
-		`handles \x1b[m (no parameter) as a reset`,
-		"\x1b[36mthis has a color\x1b[mthis is normal now\r\n",
-		"<span class=\"term-fg36\">this has a color</span>this is normal now",
-	}, {
-		`treats \x1b[39m as a reset`,
-		"\x1b[36mthis has a color\x1b[39mthis is normal now\r\n",
-		"<span class=\"term-fg36\">this has a color</span>this is normal now",
-	}, {
-		`starts overwriting characters when you \r midway through something`,
-		"hello\rb",
-		"bello",
-	}, {
-		`colors across multiple lines`,
-		"\x1b[32mhello\n\nfriend\x1b[0m",
-		"<span class=\"term-fg32\">hello</span>\n&nbsp;\n<span class=\"term-fg32\">friend</span>",
-	}, {
-		`allows you to control the cursor forwards`,
-		"this is\x1b[4Cpoop and stuff",
-		"this is    poop and stuff",
-	}, {
-		`allows you to jump down further than the bottom of the buffer`,
-		"this is great \x1b[1Bhello",
-		"this is great\n              hello",
-	}, {
-		`allows you to control the cursor backwards`,
-		"this is good\x1b[4Dpoop and stuff",
-		"this is poop and stuff",
-	}, {
-		`allows you to control the cursor upwards`,
-		"1234\n56\x1b[1A78\x1b[B",
-		"1278\n56",
-	}, {
-		`allows you to control the cursor downwards`,
+		name:  "input that ends in a newline will not include that newline",
+		input: "hello\n",
+		want:  "hello",
+	},
+	{
+		name:  "closes colors that get opened",
+		input: "he\033[32mllo",
+		want:  "he<span class=\"term-fg32\">llo</span>",
+	},
+	{
+		name:  "treats multi-byte unicode characters as individual runes",
+		input: "€€€€€€\b\b\baaa",
+		want:  "€€€aaa",
+	},
+	{
+		name:  "skips over colors when backspacing",
+		input: "he\x1b[32m\x1b[33m\bllo",
+		want:  "h<span class=\"term-fg33\">llo</span>",
+	},
+	{
+		name:  "handles \x1b[m (no parameter) as a reset",
+		input: "\x1b[36mthis has a color\x1b[mthis is normal now\r\n",
+		want:  "<span class=\"term-fg36\">this has a color</span>this is normal now",
+	},
+	{
+		name:  "treats \x1b[39m as a reset",
+		input: "\x1b[36mthis has a color\x1b[39mthis is normal now\r\n",
+		want:  "<span class=\"term-fg36\">this has a color</span>this is normal now",
+	},
+	{
+		name:  "starts overwriting characters when you carriage-return midway through something",
+		input: "hello\rb",
+		want:  "bello",
+	},
+	{
+		name:  "colors across multiple lines",
+		input: "\x1b[32mhello\n\nfriend\x1b[0m",
+		want:  "<span class=\"term-fg32\">hello</span>\n&nbsp;\n<span class=\"term-fg32\">friend</span>",
+	},
+	{
+		name:  "allows you to control the cursor forwards",
+		input: "this is\x1b[4Cpoop and stuff",
+		want:  "this is    poop and stuff",
+	},
+	{
+		name:  "allows you to jump down further than the bottom of the buffer",
+		input: "this is great \x1b[1Bhello",
+		want:  "this is great\n              hello",
+	},
+	{
+		name:  "allows you to control the cursor backwards",
+		input: "this is good\x1b[4Dpoop and stuff",
+		want:  "this is poop and stuff",
+	},
+	{
+		name:  "allows large cursor movements backwards",
+		input: strings.Repeat("w", 300) + "\x1b[300Dhahaha",
+		want:  "hahaha" + strings.Repeat("w", 294),
+	},
+	{
+		name:  "allows you to control the cursor upwards",
+		input: "1234\n56\x1b[1A78\x1b[B",
+		want:  "1278\n56",
+	},
+	{
+		name: "allows you to control the cursor downwards",
 		// creates a grid of:
 		// aaaa
 		// bbbb
@@ -99,245 +117,307 @@ var rendererTestCases = []struct {
 		// Then goes up 2 rows, down 1 row, jumps to the begining
 		// of the line, rewrites it to 1234, then jumps back down
 		// to the end of the grid.
-		"aaaa\nbbbb\ncccc\x1b[2A\x1b[1B\r1234\x1b[1B",
-		"aaaa\n1234\ncccc",
-	}, {
-		`doesn't blow up if you go back too many characters`,
-		"this is good\x1b[100Dpoop and stuff",
-		"poop and stuff",
-	}, {
-		`doesn't blow up if you backspace too many characters`,
-		"hi\b\b\b\b\b\b\b\bbye",
-		"bye",
-	}, {
-		`\x1b[1K clears everything before it`,
-		"hello\x1b[1Kfriend!",
-		"     friend!",
-	}, {
-		`clears everything after the \x1b[0K`,
-		"hello\nfriend!\x1b[A\r\x1b[0K",
-		"&nbsp;\nfriend!",
-	}, {
-		`handles \x1b[0G ghetto style`,
-		"hello friend\x1b[Ggoodbye buddy!",
-		"goodbye buddy!",
-	}, {
-		`preserves characters already written in a certain color`,
-		"  \x1b[90m․\x1b[0m\x1b[90m․\x1b[0m\x1b[0G\x1b[90m․\x1b[0m\x1b[90m․\x1b[0m",
-		"<span class=\"term-fgi90\">․․․․</span>",
-	}, {
-		`replaces empty lines with non-breaking spaces`,
-		"hello\n\nfriend",
-		"hello\n&nbsp;\nfriend",
-	}, {
-		`preserves opening colors when using \x1b[0G`,
-		"\x1b[33mhello\x1b[0m\x1b[33m\x1b[44m\x1b[0Ggoodbye",
-		"<span class=\"term-fg33 term-bg44\">goodbye</span>",
-	}, {
-		`allows clearing lines below the current line`,
-		"foo\nbar\x1b[A\x1b[Jbaz",
-		"foobaz",
-	}, {
-		`doesn't freak out about clearing lines below when there aren't any`,
-		"foobar\x1b[0J",
-		"foobar",
-	}, {
-		`allows clearing lines above the current line`,
-		"foo\nbar\x1b[A\x1b[1Jbaz",
-		"barbaz",
-	}, {
-		`doesn't freak out about clearing lines above when there aren't any`,
-		"\x1b[1Jfoobar",
-		"foobar",
-	}, {
-		`allows clearing the entire scrollback buffer with escape 2J`,
-		"this is a big long bit of terminal output\nplease pay it no mind, we will clear it soon\nokay, get ready for a disappearing act...\nand...and...\n\n\x1b[2Jhey presto",
-		"hey presto",
-	}, {
-		`allows clearing the entire scrollback buffer with escape 3J also`,
-		"this is a big long bit of terminal output\nplease pay it no mind, we will clear it soon\nokay, get ready for a disappearing act...\nand...and...\n\n\x1b[2Jhey presto",
-		"hey presto",
-	}, {
-		`allows erasing the current line up to a point`,
-		"hello friend\x1b[1K!",
-		"            !",
-	}, {
-		`allows clearing of the current line`,
-		"hello friend\x1b[2K!",
-		"            !",
-	}, {
-		`doesn't close spans if no colors have been opened`,
-		"hello \x1b[0mfriend",
-		"hello friend",
-	}, {
-		`\x1b[K correctly clears all previous parts of the string`,
-		"remote: Compressing objects:   0% (1/3342)\x1b[K\rremote: Compressing objects:   1% (34/3342)",
-		"remote: Compressing objects:   1% (34&#47;3342)",
-	}, {
-		`handles reverse linefeed`,
-		"meow\npurr\nnyan\x1bMrawr",
-		"meow\npurrrawr\nnyan",
-	}, {
-		`collapses many spans of the same color into 1`,
-		"\x1b[90m․\x1b[90m․\x1b[90m․\x1b[90m․\n\x1b[90m․\x1b[90m․\x1b[90m․\x1b[90m․",
-		"<span class=\"term-fgi90\">․․․․</span>\n<span class=\"term-fgi90\">․․․․</span>",
-	}, {
-		`escapes HTML`,
-		"hello <strong>friend</strong>",
-		"hello &lt;strong&gt;friend&lt;&#47;strong&gt;",
-	}, {
-		`escapes HTML in color codes`,
-		"hello \x1b[\"hellomfriend",
-		"hello [&quot;hellomfriend",
-	}, {
-		`handles background colors`,
-		"\x1b[30;42m\x1b[2KOK (244 tests, 558 assertions)",
-		"<span class=\"term-fg30 term-bg42\">OK (244 tests, 558 assertions)</span>",
-	}, {
-		`does not attempt to incorrectly nest CSS in HTML (https://github.com/buildkite/terminal-to-html/issues/36)`,
-		"Some plain text\x1b[0;30;42m yay a green background \x1b[0m\x1b[0;33;49mnow this has no background but is yellow \x1b[0m",
-		"Some plain text<span class=\"term-fg30 term-bg42\"> yay a green background </span><span class=\"term-fg33\">now this has no background but is yellow </span>",
-	}, {
-		`handles xterm colors`,
-		"\x1b[38;5;169;48;5;50mhello\x1b[0m \x1b[38;5;179mgoodbye",
-		"<span class=\"term-fgx169 term-bgx50\">hello</span> <span class=\"term-fgx179\">goodbye</span>",
-	}, {
-		`handles non-xterm codes on the same line as xterm colors`,
-		"\x1b[38;5;228;5;1mblinking and bold\x1b",
-		`<span class="term-fgx228 term-fg1 term-fg5">blinking and bold</span>`,
-	}, {
-		`ignores broken escape characters, stripping the escape rune itself`,
-		"hi amazing \x1b[12 nom nom nom friends",
-		"hi amazing [12 nom nom nom friends",
-	}, {
-		`handles colors with 3 attributes`,
-		"\x1b[0;10;4m\x1b[1m\x1b[34mgood news\x1b[0;10m\n\neveryone",
-		"<span class=\"term-fg34 term-fg1 term-fg4\">good news</span>\n&nbsp;\neveryone",
-	}, {
-		`ends underlining with \x1b[24`,
-		"\x1b[4mbegin\x1b[24m\r\nend",
-		"<span class=\"term-fg4\">begin</span>\nend",
-	}, {
-		`ends bold with \x1b[21`,
-		"\x1b[1mbegin\x1b[21m\r\nend",
-		"<span class=\"term-fg1\">begin</span>\nend",
-	}, {
-		`ends bold with \x1b[22`,
-		"\x1b[1mbegin\x1b[22m\r\nend",
-		"<span class=\"term-fg1\">begin</span>\nend",
-	}, {
-		`ends crossed out with \x1b[29`,
-		"\x1b[9mbegin\x1b[29m\r\nend",
-		"<span class=\"term-fg9\">begin</span>\nend",
-	}, {
-		`ends italic out with \x1b[23`,
-		"\x1b[3mbegin\x1b[23m\r\nend",
-		"<span class=\"term-fg3\">begin</span>\nend",
-	}, {
-		`ends decreased intensity with \x1b[22`,
-		"\x1b[2mbegin\x1b[22m\r\nend",
-		"<span class=\"term-fg2\">begin</span>\nend",
-	}, {
-		`ignores cursor show/hide`,
-		"\x1b[?25ldoing a thing without a cursor\x1b[?25h",
-		"doing a thing without a cursor",
-	}, {
-		`renders simple images on their own line`, // http://iterm2.com/images.html
-		"hi\x1b]1337;File=name=MS5naWY=;inline=1:AA==\ahello",
-		"hi\n" + `<img alt="1.gif" src="data:image/gif;base64,AA==">` + "\nhello",
-	}, {
-		`does not start a new line for iterm images if we're already at the start of a line`,
-		"\x1b]1337;File=name=MS5naWY=;inline=1:AA==\a",
-		`<img alt="1.gif" src="data:image/gif;base64,AA==">`,
-	}, {
-		`silently ignores unsupported ANSI escape sequences`,
-		"abc\x1b]9999\aghi",
-		"abcghi",
-	}, {
-		`correctly handles images that we decide not to render`,
-		"hi\x1b]1337;File=name=MS5naWY=;inline=0:AA==\ahello",
-		"hihello",
-	}, {
-		`renders external images`,
-		"\x1b]1338;url=http://foo.com/foobar.gif;alt=foo bar\a",
-		`<img alt="foo bar" src="http://foo.com/foobar.gif">`,
-	}, {
-		`disallows non-allow-listed schemes for images`,
-		"before\x1b]1338;url=javascript:alert(1);alt=hello\x07after",
-		"before\n&nbsp;\nafter", // don't really care about the middle, as long as it's white-spacey
-	}, {
-		`renders links, and renders them inline on other content`,
-		"a link to \x1b]1339;url=http://google.com;content=google\a.",
-		`a link to <a href="http://google.com">google</a>.`,
-	}, {
-		"renders OSC 8 links",
-		"a link to \x1b]8;;http://google.com\x1b\\google\x1b]8;;\x1b\\.",
-		`a link to <a href="http://google.com">google</a>.`,
-	}, {
-		`uses URL as link content if missing`,
-		"\x1b]1339;url=http://google.com\a",
-		`<a href="http://google.com">http://google.com</a>`,
-	}, {
-		`protects inline images against XSS by escaping HTML during rendering`,
-		"hi\x1b]1337;File=name=" + base64Encode("<script>.pdf") + ";inline=1:AA==\ahello",
-		"hi\n" + `<img alt="&lt;script&gt;.pdf" src="data:application/pdf;base64,AA==">` + "\nhello",
-	}, {
-		`protects external images against XSS by escaping HTML during rendering`,
-		"\x1b]1338;url=\"https://example.com/a.gif&a=<b>&c='d'\";alt=foo&bar;width=\"<wat>\";height=2px\a",
-		`<img alt="foo&amp;bar" src="https://example.com/a.gif&amp;a=%3Cb%3E&amp;c=%27d%27" width="&lt;wat&gt;em" height="2px">`,
-	}, {
-		`protects links against XSS by escaping HTML during rendering`,
-		"\x1b]1339;url=\"https://example.com/a.gif&a=<b>&c='d'\";content=<h1>hello</h1>\a",
-		`<a href="https://example.com/a.gif&amp;a=%3Cb%3E&amp;c=%27d%27">&lt;h1&gt;hello&lt;/h1&gt;</a>`,
-	}, {
-		"protects OSC 8 links against XSS by escaping HTML during rendering",
-		"a link to \x1b]8;;https://example.com/a.gif&a=<b>&c='d'\x1b\\<h1>hello</h1>\x1b]8;;\x1b\\.",
-		`a link to <a href="https://example.com/a.gif&amp;a=%3Cb%3E&amp;c=%27d%27">&lt;h1&gt;hello&lt;&#47;h1&gt;</a>.`,
-	}, {
-		`disallows javascript: scheme URLs`,
-		"\x1b]1339;url=javascript:alert(1);content=hello\x07",
-		`<a href="#">hello</a>`,
-	}, {
-		`disallows javascript: scheme URLs in OSC 8 links`,
-		"\x1b]8;;javascript:alert(1)\x07XSS!\x1b]8;;\x1b\\",
-		`<a href="#">XSS!</a>`,
-	}, {
-		`allows artifact: scheme URLs`,
-		"\x1b]1339;url=artifact://hello.txt\x07\n",
-		`<a href="artifact://hello.txt">artifact://hello.txt</a>`,
-	}, {
-		`allows artifact: scheme URLs in OSC 8 links`,
-		"\x1b]8;;artifact://hello.txt\x07the hello.txt artifact\x1b]8;;\x07\n",
-		`<a href="artifact://hello.txt">the hello.txt artifact</a>`,
-	}, {
-		`renders bk APC escapes followed by text`,
-		"\x1b_bk;t=123\x07hello",
-		`<time datetime="1970-01-01T00:00:00.123Z">1970-01-01T00:00:00.123Z</time>hello`,
-	}, {
-		`handles bk APC escapes surrounded by text`,
-		"hello \x1b_bk;t=123\x07world",
-		`<time datetime="1970-01-01T00:00:00.123Z">1970-01-01T00:00:00.123Z</time>hello world`,
-	}, {
-		`prefixes lines with the last timestamp seen`,
-		"hello\x1b_bk;t=123\x07 world\x1b_bk;t=456\x07!",
-		`<time datetime="1970-01-01T00:00:00.456Z">1970-01-01T00:00:00.456Z</time>hello world!`,
-	}, {
-		`handles timestamps across multiple lines`,
-		strings.Join([]string{
+		input: "aaaa\nbbbb\ncccc\x1b[2A\x1b[1B\r1234\x1b[1B",
+		want:  "aaaa\n1234\ncccc",
+	},
+	{
+		name:  "doesn't blow up if you go back too many characters",
+		input: "this is good\x1b[100Dpoop and stuff",
+		want:  "poop and stuff",
+	},
+	{
+		name:  "doesn't blow up if you backspace too many characters",
+		input: "hi\b\b\b\b\b\b\b\bbye",
+		want:  "bye",
+	},
+	{
+		name:  "ESC [1K clears everything before it",
+		input: "hello\x1b[1Kfriend!",
+		want:  "     friend!",
+	},
+	{
+		name:  "clears everything after ESC [0K",
+		input: "hello\nfriend!\x1b[A\r\x1b[0K",
+		want:  "&nbsp;\nfriend!",
+	},
+	{
+		name:  "handles ESC [0G",
+		input: "hello friend\x1b[Ggoodbye buddy!",
+		want:  "goodbye buddy!",
+	},
+	{
+		name:  "preserves characters already written in a certain color",
+		input: "  \x1b[90m․\x1b[0m\x1b[90m․\x1b[0m\x1b[0G\x1b[90m․\x1b[0m\x1b[90m․\x1b[0m",
+		want:  "<span class=\"term-fgi90\">․․․․</span>",
+	},
+	{
+		name:  "replaces empty lines with non-breaking spaces",
+		input: "hello\n\nfriend",
+		want:  "hello\n&nbsp;\nfriend",
+	},
+	{
+		name:  "preserves opening colors when using ESC [0G",
+		input: "\x1b[33mhello\x1b[0m\x1b[33m\x1b[44m\x1b[0Ggoodbye",
+		want:  "<span class=\"term-fg33 term-bg44\">goodbye</span>",
+	},
+	{
+		name:  "allows cursor movement with ESC [...H",
+		input: "line 1\nline 2\nline 3\n\x1b[2;3Hm",
+		want:  "line 1\nlime 2\nline 3",
+	},
+	{
+		name:  "allows clearing lines below the current line",
+		input: "foo\nbar\x1b[A\x1b[Jbaz",
+		want:  "foobaz",
+	},
+	{
+		name:  "doesn't freak out about clearing lines below when there aren't any",
+		input: "foobar\x1b[0J",
+		want:  "foobar",
+	},
+	{
+		name:  "allows clearing lines above the current line",
+		input: "foo\nbar\nbaz\x1b[A\x1b[1Jqux",
+		want:  "&nbsp;\n   qux\nbaz",
+	},
+	{
+		name:  "doesn't freak out about clearing lines above when there aren't any",
+		input: "\x1b[1Jfoobar",
+		want:  "foobar",
+	},
+	{
+		name:  "allows clearing the entire scrollback buffer with ESC [2J",
+		input: "this is a big long bit of terminal output\nplease pay it no mind, we will clear it soon\nokay, get ready for a disappearing act...\nand...and...\n\n\x1b[2Jhey presto",
+		want:  "hey presto",
+	},
+	{
+		name:  "allows clearing the entire scrollback buffer with ESC [3J also",
+		input: "this is a big long bit of terminal output\nplease pay it no mind, we will clear it soon\nokay, get ready for a disappearing act...\nand...and...\n\n\x1b[2Jhey presto",
+		want:  "hey presto",
+	},
+	{
+		name:  "allows erasing the current line up to a point",
+		input: "hello friend\x1b[1K!",
+		want:  "            !",
+	},
+	{
+		name:  "allows clearing of the current line",
+		input: "hello friend\x1b[2K!",
+		want:  "            !",
+	},
+	{
+		name:  "doesn't close spans if no colors have been opened",
+		input: "hello \x1b[0mfriend",
+		want:  "hello friend",
+	},
+	{
+		name:  "ESC [K correctly clears all previous parts of the string",
+		input: "remote: Compressing objects:   0% (1/3342)\x1b[K\rremote: Compressing objects:   1% (34/3342)",
+		want:  "remote: Compressing objects:   1% (34&#47;3342)",
+	},
+	{
+		name:  "handles reverse linefeed",
+		input: "meow\npurr\nnyan\x1bMrawr",
+		want:  "meow\npurrrawr\nnyan",
+	},
+	{
+		name:  "collapses many spans of the same color into 1",
+		input: "\x1b[90m․\x1b[90m․\x1b[90m․\x1b[90m․\n\x1b[90m․\x1b[90m․\x1b[90m․\x1b[90m․",
+		want:  "<span class=\"term-fgi90\">․․․․</span>\n<span class=\"term-fgi90\">․․․․</span>",
+	},
+	{
+		name:  "escapes HTML",
+		input: "hello <strong>friend</strong>",
+		want:  "hello &lt;strong&gt;friend&lt;&#47;strong&gt;",
+	},
+	{
+		name:  "escapes HTML in color codes",
+		input: "hello \x1b[\"hellomfriend",
+		want:  "hello [&quot;hellomfriend",
+	},
+	{
+		name:  "handles background colors",
+		input: "\x1b[30;42m\x1b[2KOK (244 tests, 558 assertions)",
+		want:  "<span class=\"term-fg30 term-bg42\">OK (244 tests, 558 assertions)</span>",
+	},
+	{
+		name:  "does not attempt to incorrectly nest CSS in HTML (https://github.com/buildkite/terminal-to-html/issues/36)",
+		input: "Some plain text\x1b[0;30;42m yay a green background \x1b[0m\x1b[0;33;49mnow this has no background but is yellow \x1b[0m",
+		want:  "Some plain text<span class=\"term-fg30 term-bg42\"> yay a green background </span><span class=\"term-fg33\">now this has no background but is yellow </span>",
+	},
+	{
+		name:  "handles xterm colors",
+		input: "\x1b[38;5;169;48;5;50mhello\x1b[0m \x1b[38;5;179mgoodbye",
+		want:  "<span class=\"term-fgx169 term-bgx50\">hello</span> <span class=\"term-fgx179\">goodbye</span>",
+	},
+	{
+		name:  "handles non-xterm codes on the same line as xterm colors",
+		input: "\x1b[38;5;228;5;1mblinking and bold\x1b",
+		want:  `<span class="term-fgx228 term-fg1 term-fg5">blinking and bold</span>`,
+	},
+	{
+		name:  "ignores broken escape characters, stripping the escape rune itself",
+		input: "hi amazing \x1b[12 nom nom nom friends",
+		want:  "hi amazing [12 nom nom nom friends",
+	},
+	{
+		name:  "handles colors with 3 attributes",
+		input: "\x1b[0;10;4m\x1b[1m\x1b[34mgood news\x1b[0;10m\n\neveryone",
+		want:  "<span class=\"term-fg34 term-fg1 term-fg4\">good news</span>\n&nbsp;\neveryone",
+	},
+	{
+		name:  "ends underlining with ESC [24m",
+		input: "\x1b[4mbegin\x1b[24m\r\nend",
+		want:  "<span class=\"term-fg4\">begin</span>\nend",
+	},
+	{
+		name:  "ends bold with ESC [21m",
+		input: "\x1b[1mbegin\x1b[21m\r\nend",
+		want:  "<span class=\"term-fg1\">begin</span>\nend",
+	},
+	{
+		name:  "ends bold with ESC [22m",
+		input: "\x1b[1mbegin\x1b[22m\r\nend",
+		want:  "<span class=\"term-fg1\">begin</span>\nend",
+	},
+	{
+		name:  "ends crossed out with ESC [29m",
+		input: "\x1b[9mbegin\x1b[29m\r\nend",
+		want:  "<span class=\"term-fg9\">begin</span>\nend",
+	},
+	{
+		name:  "ends italic out with \x1b[23m",
+		input: "\x1b[3mbegin\x1b[23m\r\nend",
+		want:  "<span class=\"term-fg3\">begin</span>\nend",
+	},
+	{
+		name:  "ends decreased intensity with \x1b[22m",
+		input: "\x1b[2mbegin\x1b[22m\r\nend",
+		want:  "<span class=\"term-fg2\">begin</span>\nend",
+	},
+	{
+		name:  "ignores cursor show/hide",
+		input: "\x1b[?25ldoing a thing without a cursor\x1b[?25h",
+		want:  "doing a thing without a cursor",
+	},
+	{
+		name:  "renders simple images on their own line", // http://iterm2.com/images.html
+		input: "hi\x1b]1337;File=name=MS5naWY=;inline=1:AA==\ahello",
+		want:  "hi\n" + `<img alt="1.gif" src="data:image/gif;base64,AA==">` + "\nhello",
+	},
+	{
+		name:  "does not start a new line for iterm images if we're already at the start of a line",
+		input: "\x1b]1337;File=name=MS5naWY=;inline=1:AA==\a",
+		want:  `<img alt="1.gif" src="data:image/gif;base64,AA==">`,
+	},
+	{
+		name:  "silently ignores unsupported ANSI escape sequences",
+		input: "abc\x1b]9999\aghi",
+		want:  "abcghi",
+	},
+	{
+		name:  "correctly handles images that we decide not to render",
+		input: "hi\x1b]1337;File=name=MS5naWY=;inline=0:AA==\ahello",
+		want:  "hihello",
+	},
+	{
+		name:  "renders external images",
+		input: "\x1b]1338;url=http://foo.com/foobar.gif;alt=foo bar\a",
+		want:  `<img alt="foo bar" src="http://foo.com/foobar.gif">`,
+	},
+	{
+		name:  "disallows non-allow-listed schemes for images",
+		input: "before\x1b]1338;url=javascript:alert(1);alt=hello\x07after",
+		want:  "before\n&nbsp;\nafter", // don't really care about the middle, as long as it's white-spacey
+	},
+	{
+		name:  "renders links, and renders them inline on other content",
+		input: "a link to \x1b]1339;url=http://google.com;content=google\a.",
+		want:  `a link to <a href="http://google.com">google</a>.`,
+	},
+	{
+		name:  "renders OSC 8 links",
+		input: "a link to \x1b]8;;http://google.com\x1b\\google\x1b]8;;\x1b\\.",
+		want:  `a link to <a href="http://google.com">google</a>.`,
+	},
+	{
+		name:  "uses URL as link content if missing",
+		input: "\x1b]1339;url=http://google.com\a",
+		want:  `<a href="http://google.com">http://google.com</a>`,
+	},
+	{
+		name:  "protects inline images against XSS by escaping HTML during rendering",
+		input: "hi\x1b]1337;File=name=" + base64Encode("<script>.pdf") + ";inline=1:AA==\ahello",
+		want:  "hi\n" + `<img alt="&lt;script&gt;.pdf" src="data:application/pdf;base64,AA==">` + "\nhello",
+	},
+	{
+		name:  "protects external images against XSS by escaping HTML during rendering",
+		input: "\x1b]1338;url=\"https://example.com/a.gif&a=<b>&c='d'\";alt=foo&bar;width=\"<wat>\";height=2px\a",
+		want:  `<img alt="foo&amp;bar" src="https://example.com/a.gif&amp;a=%3Cb%3E&amp;c=%27d%27" width="&lt;wat&gt;em" height="2px">`,
+	},
+	{
+		name:  "protects links against XSS by escaping HTML during rendering",
+		input: "\x1b]1339;url=\"https://example.com/a.gif&a=<b>&c='d'\";content=<h1>hello</h1>\a",
+		want:  `<a href="https://example.com/a.gif&amp;a=%3Cb%3E&amp;c=%27d%27">&lt;h1&gt;hello&lt;/h1&gt;</a>`,
+	},
+	{
+		name:  "protects OSC 8 links against XSS by escaping HTML during rendering",
+		input: "a link to \x1b]8;;https://example.com/a.gif&a=<b>&c='d'\x1b\\<h1>hello</h1>\x1b]8;;\x1b\\.",
+		want:  `a link to <a href="https://example.com/a.gif&amp;a=%3Cb%3E&amp;c=%27d%27">&lt;h1&gt;hello&lt;&#47;h1&gt;</a>.`,
+	},
+	{
+		name:  "disallows javascript: scheme URLs",
+		input: "\x1b]1339;url=javascript:alert(1);content=hello\x07",
+		want:  `<a href="#">hello</a>`,
+	},
+	{
+		name:  "disallows javascript: scheme URLs in OSC 8 links",
+		input: "\x1b]8;;javascript:alert(1)\x07XSS!\x1b]8;;\x1b\\",
+		want:  `<a href="#">XSS!</a>`,
+	},
+	{
+		name:  "allows artifact: scheme URLs",
+		input: "\x1b]1339;url=artifact://hello.txt\x07\n",
+		want:  `<a href="artifact://hello.txt">artifact://hello.txt</a>`,
+	},
+	{
+		name:  "allows artifact: scheme URLs in OSC 8 links",
+		input: "\x1b]8;;artifact://hello.txt\x07the hello.txt artifact\x1b]8;;\x07\n",
+		want:  `<a href="artifact://hello.txt">the hello.txt artifact</a>`,
+	},
+	{
+		name:  "renders bk APC escapes followed by text",
+		input: "\x1b_bk;t=123\x07hello",
+		want:  `<time datetime="1970-01-01T00:00:00.123Z">1970-01-01T00:00:00.123Z</time>hello`,
+	},
+	{
+		name:  "handles bk APC escapes surrounded by text",
+		input: "hello \x1b_bk;t=123\x07world",
+		want:  `<time datetime="1970-01-01T00:00:00.123Z">1970-01-01T00:00:00.123Z</time>hello world`,
+	},
+	{
+		name:  "prefixes lines with the last timestamp seen",
+		input: "hello\x1b_bk;t=123\x07 world\x1b_bk;t=456\x07!",
+		want:  `<time datetime="1970-01-01T00:00:00.456Z">1970-01-01T00:00:00.456Z</time>hello world!`,
+	},
+	{
+		name: "handles timestamps across multiple lines",
+		input: strings.Join([]string{
 			"hello\x1b_bk;t=123\x07 world\x1b_bk;t=234\x07!",
 			"another\x1b_bk;t=345\x07 line\x1b_bk;t=456\x07!",
 		}, "\n"),
-		strings.Join([]string{
+		want: strings.Join([]string{
 			`<time datetime="1970-01-01T00:00:00.234Z">1970-01-01T00:00:00.234Z</time>hello world!`,
 			`<time datetime="1970-01-01T00:00:00.456Z">1970-01-01T00:00:00.456Z</time>another line!`,
 		}, "\n"),
-	}, {
-		`handles timestamps and delta timestamps`,
-		strings.Join([]string{
+	},
+	{
+		name: "handles timestamps and delta timestamps",
+		input: strings.Join([]string{
 			"hello\x1b_bk;t=123\x07 world\x1b_bk;dt=111\x07!",
 			"another\x1b_bk;dt=111\x07 line\x1b_bk;dt=111\x07!",
 		}, "\n"),
-		strings.Join([]string{
+		want: strings.Join([]string{
 			`<time datetime="1970-01-01T00:00:00.234Z">1970-01-01T00:00:00.234Z</time>hello world!`,
 			`<time datetime="1970-01-01T00:00:00.456Z">1970-01-01T00:00:00.456Z</time>another line!`,
 		}, "\n"),
@@ -348,7 +428,7 @@ func TestRendererAgainstCases(t *testing.T) {
 	for _, c := range rendererTestCases {
 		t.Run(c.name, func(t *testing.T) {
 			got := Render([]byte(c.input))
-			want := c.expected
+			want := c.want
 
 			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf("Render(%q) diff (-got +want):\n%s", c.input, diff)
@@ -372,14 +452,13 @@ func TestRendererAgainstFixtures(t *testing.T) {
 	}
 }
 
-func streamingRender(raw []byte) string {
+func streamingRender(t testing.TB, raw []byte) string {
 	var buf strings.Builder
-	s := &Screen{
-		MaxLines: 300,
-		ScrollOutFunc: func(line string) {
-			fmt.Fprintln(&buf, line)
-		},
+	s, err := NewScreen(WithMaxSize(-1, 300))
+	if err != nil {
+		t.Fatalf("NewScreen error: %v", err)
 	}
+	s.ScrollOutFunc = func(line string) { fmt.Fprintln(&buf, line) }
 	s.Write(raw)
 	buf.WriteString(s.AsHTML())
 	return buf.String()
@@ -388,8 +467,8 @@ func streamingRender(raw []byte) string {
 func TestStreamingRendererAgainstCases(t *testing.T) {
 	for _, c := range rendererTestCases {
 		t.Run(c.name, func(t *testing.T) {
-			got := streamingRender([]byte(c.input))
-			want := c.expected
+			got := streamingRender(t, []byte(c.input))
+			want := c.want
 
 			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf("streamingRender(%q) diff (-got +want):\n%s", c.input, diff)
@@ -404,7 +483,7 @@ func TestStreamingRendererAgainstFixtures(t *testing.T) {
 			raw := loadFixture(t, base, "raw")
 			want := string(loadFixture(t, base, "rendered"))
 
-			got := streamingRender(raw)
+			got := streamingRender(t, raw)
 
 			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf("streamingRender diff (-got +want):\n%s", diff)
@@ -414,7 +493,10 @@ func TestStreamingRendererAgainstFixtures(t *testing.T) {
 }
 
 func TestScreenWriteToXY(t *testing.T) {
-	s := Screen{style: 0}
+	s, err := NewScreen()
+	if err != nil {
+		t.Fatalf("NewScreen() error = %v", err)
+	}
 	s.write('a')
 
 	s.x = 1
@@ -466,10 +548,12 @@ func benchmarkStreaming(filename string, b *testing.B) {
 	raw := loadFixture(b, filename, "raw")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s := &Screen{
-			MaxLines:      300,
-			ScrollOutFunc: func(string) {},
+		s, err := NewScreen(WithMaxSize(-1, 300))
+		if err != nil {
+			b.Fatalf("NewScreen(WithMaxSize(-1, 300)) error = %v", err)
 		}
+		// Set a non-nil scroll out func to exercise the codepath.
+		s.ScrollOutFunc = func(line string) {}
 		s.Write(raw)
 		_ = s.AsHTML()
 	}


### PR DESCRIPTION
### What

Replace `strconv.ParseInt(s, 10, 8)` with `strconv.Atoi(s)`.

And then shave all the yaks:

- Implement window sizes with a default of 160 x 100.
- Implement window size limits.
- Implement ESC [ _n_;_m_ H
- Implement ESC [ _n_ J properly
- Rearrange various bits of code

Fixes #143 

### Why

`strconv.ParseInt(s, 10, 8)` can't count bigger than 127. So we should swap it with a parser than can parse bigger numbers.

How big though? The easy answer is to choose a function with a shorter name, which is `strconv.Atoi`. This parses them up to 64 bits (equivalent to `strconv.ParseInt(s, 10, 64)`). 

Why all the extra change though? Well...

The number is used, among other things, for cursor movement. `ESC [ n A` and `ESC [ n C` cause calls to `*Screen.down` and `*Screen.forward`, respectively. They looked like this:

```go
// Move the cursor down
func (s *Screen) down(i string) {
	s.y += ansiInt(i)
}

// Move the cursor forward on the line
func (s *Screen) forward(i string) {
	s.x += ansiInt(i)
}
```

No problem so far. What happens when we try to write a character at the new cursor position? `getCurrentLineForWriting` allocates more screen lines and more nodes within the current screen line to be able to write the character.

With the cursor parameters limited to a maximum of 127, the worst that could happen is about a kilobyte of memory is allocated (in the x direction) or some other small amount (in the y direction).

If the cursor parameter can be 2**63-1... well... let's just say I doubt we have the memory for that.

Real terminals (and serious terminal emulators) bound cursor movements to the window. That is, `ESC [ 9999999999999 A` and `ESC [ 9999999999999 C` would stop at the bottom and right edge of the terminal, respectively (unless you have a terminal window bigger than that). We already bound cursor movements when going up or back, so to prevent trivially exhausting memory, and to do basically the same thing as every serious terminal / emulator, we need to bound cursor movements going down or forward (and all the other commands).

To do that we need to define a window size. To begin with it will default to the same size buildkite-agent is now using (160 x 100), but this is otherwise a fairly arbitrary choice.

Note that lines can exceed the window width: this is similar to what iTerm2 does, where you can keep typing on the same line. From a memory consumption perspective this could be concerning, but the only way to do this should be with plain text, not cursor movements. (Memory consumption should be at worst linear in the input size.) Visually, the line wraps, logically it does not. But if you then use an ANSI sequence to move the cursor, it was as though the line _had_ hard-wrapped.

With window sizing implemented, `ESC [H` becomes reasonable to implement, and `ESC [2J` and `ESC [3J` have meaningfully different interpretations. `ESC [1J` seems to have had a potential bug in it: iTerm2 for example clears the screen above the cursor, but leaves the cursor in the current location, meaning that truncating `s.screen` to clear the lines above is probably not the right implementation. I uncovered this because if the intent of `ESC [1J` is to only clear the current window to the cursor, then truncation would remove the "scrollback" existing between the window and the `maxLines` limit.

Anyway, it's been a day of pulling on threads like that.