### PR TITLE
Bump version to v3.16.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.15.0"
+var baseVersion string = "3.16.0"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.16.0](https://github.com/buildkite/terminal-to-html/tree/v3.16.0) (2024-09-02)
[Full Changelog](https://github.com/buildkite/terminal-to-html/compare/v3.15.0...v3.16.0)

### Fixed
- Teach terminal-to-html about numbers bigger than 127 [#177](https://github.com/buildkite/terminal-to-html/pull/177) (@DrJosh9000)
