### PR TITLE
Bump version to v3.16.3

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.16.2"
+var baseVersion string = "3.16.3"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.16.3](https://github.com/buildkite/terminal-to-html/tree/v3.16.3) (2024-10-16)
[Full Changelog](https://github.com/buildkite/terminal-to-html/compare/v3.16.2...v3.16.3)

### Fixed
- Fix ESC [J commands [#190](https://github.com/buildkite/terminal-to-html/pull/190) (@DrJosh9000)

### Dependabot
- Bump docker/library/golang from `adee809` to `a7f2fc9` [#188](https://github.com/buildkite/terminal-to-html/pull/188) (@dependabot[bot])
- Bump github.com/urfave/cli/v2 from 2.27.4 to 2.27.5 [#189](https://github.com/buildkite/terminal-to-html/pull/189) (@dependabot[bot])
- Bump docker/library/golang from 1.23.1 to 1.23.2 [#186](https://github.com/buildkite/terminal-to-html/pull/186) (@dependabot[bot])
- Bump golang.org/x/sys from 0.25.0 to 0.26.0 [#187](https://github.com/buildkite/terminal-to-html/pull/187) (@dependabot[bot])
- Bump docker/library/golang from `2fe82a3` to `4f063a2` [#185](https://github.com/buildkite/terminal-to-html/pull/185) (@dependabot[bot])
- Bump docker/library/golang from `4a3c2bc` to `2fe82a3` [#184](https://github.com/buildkite/terminal-to-html/pull/184) (@dependabot[bot])