### PR TITLE
Only stream out whole lines

### DIFF
--- a/cmd/terminal-to-html/terminal-to-html.go
+++ b/cmd/terminal-to-html/terminal-to-html.go
@@ -178,9 +178,7 @@ func (wc *writeCounter) Write(b []byte) (int, error) {
 	return n, err
 }
 
-func (wc *writeCounter) WriteString(s string) {
-	wc.out.Write([]byte(s))
-}
+func (wc *writeCounter) WriteString(s string) { wc.Write([]byte(s)) }
 
 // process streams the src through a terminal renderer to the dst. If preview is
 // true, the preview wrapper is added.

--- a/output_test.go
+++ b/output_test.go
@@ -38,9 +38,9 @@ func TestScreenLineAsHTML_Interleaving(t *testing.T) {
 				t.Fatalf("len(s.screen) = %d, want 1", len(s.screen))
 			}
 
-			got := s.screen[0].asHTML(true)
+			got := lineToHTML(s.screen[:1])
 			if diff := cmp.Diff(got, test.want); diff != "" {
-				t.Errorf("s.screen[0].asHTML diff (-got +want):\n%s", diff)
+				t.Errorf("lineToHTML(s.screen[:1]) diff (-got +want):\n%s", diff)
 			}
 		})
 	}

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.16.6"
+var baseVersion string = "3.16.7"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
### What
Ensure only whole lines (ending in `\n`) are written to the output at a time.

### Why
There was a latent streaming processing issue: it assumed all intermediate chunks of output ended in `\n`, but #210 changed the output so that sometimes, screen lines could be scrolled out without `\n` (if they continued on to the following screen line).

### How
The only trick here is to render multiple `screenLine`s at once, and pull them off the top of the screen buffer together. This has the added benefit of minimising HTML tags needing to be closed and reopened straight away on the same line (as it used to be before #205).

Since multiple `screenLines` can now be scrolled out at once, the recycling optimisation that previously assumed there would only be 1 line scrolling out at a time is now generalised to store excess backing arrays in `nodeRecycling` and consume them later.