### PR TITLE
Bump version to v3.16.8

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.16.7"
+var baseVersion string = "3.16.8"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.16.8](https://github.com/buildkite/terminal-to-html/tree/v3.16.8) (2025-03-25)
[Full Changelog](https://github.com/buildkite/terminal-to-html/compare/v3.16.7...v3.16.8)

### Changed
- Bump docker/library/golang from `fa145a3` to `52ff1b3` [#222](https://github.com/buildkite/terminal-to-html/pull/222) (@dependabot[bot])
- Bump docker/library/golang from `c5adecd` to `fa145a3` [#220](https://github.com/buildkite/terminal-to-html/pull/220) (@dependabot[bot])
- Bump golang.org/x/sys from 0.30.0 to 0.31.0 [#218](https://github.com/buildkite/terminal-to-html/pull/218) (@dependabot[bot])
- Bump docker/library/golang from 1.24.0 to 1.24.1 [#217](https://github.com/buildkite/terminal-to-html/pull/217) (@dependabot[bot])
- Bump github.com/urfave/cli/v2 from 2.27.5 to 2.27.6 [#219](https://github.com/buildkite/terminal-to-html/pull/219) (@dependabot[bot])
- Bump docker/library/golang from `2b1cbf2` to `3f74443` [#216](https://github.com/buildkite/terminal-to-html/pull/216) (@dependabot[bot])
