### PR TITLE
Handle parsing 24 bit colors

### DIFF
--- a/style.go
+++ b/style.go
@@ -2,16 +2,20 @@ package terminal
 
 import "strconv"
 
-type style uint32
+type style uint64
 
 // style encoding:
-// 0...  ...7  8... ...15  16...23     24     25   26....31
-// [fg color]  [bg color]  [flags]  element  link  [unused]
+// 0... ...23  24... ...47  48...59     60     61   62....63
+// [fg color]  [bg color]   [flags]  element  link  [unused]
 // flags = bold, faint, etc
 
 const (
-	sbFGColorX = 1 << (16 + iota)
-	sbBGColorX
+	sbFGColorX1 = style(1) << (48 + iota)
+	sbFGColorX2
+	sbFGColorX3
+	sbBGColorX1
+	sbBGColorX2
+	sbBGColorX3
 	sbBold
 	sbFaint
 	sbItalic
@@ -22,30 +26,50 @@ const (
 	sbHyperlink // this node is styled with an OSC 8 (iTerm-style) link
 )
 
+const (
+	sbFGColorX = sbFGColorX1 | sbFGColorX2 | sbFGColorX3
+	sbBGColorX = sbBGColorX1 | sbBGColorX2 | sbBGColorX3
+)
+
+const (
+	colorNone = uint8(iota)
+	colorDefault
+	colorSGR
+	color8Bit
+	color24Bit
+)
+
+
 // Used for comparing styles - ignores the element bit, link bit, and unused bits.
-const styleComparisonMask = 0x00ffffff
+const styleComparisonMask = 0x0fff_ffff_ffff_ffff
 
 // isPlain reports if there is no style information. elements (that have no
 // other style set) are also considered plain.
 func (s style) isPlain() bool { return s&styleComparisonMask == 0 }
 
-func (s style) fgColor() uint8  { return uint8(s & 0xff) }
-func (s style) bgColor() uint8  { return uint8((s & 0xff_00) >> 8) }
-func (s style) fgColorX() bool  { return s&sbFGColorX != 0 }
-func (s style) bgColorX() bool  { return s&sbBGColorX != 0 }
-func (s style) bold() bool      { return s&sbBold != 0 }
-func (s style) faint() bool     { return s&sbFaint != 0 }
-func (s style) italic() bool    { return s&sbItalic != 0 }
-func (s style) underline() bool { return s&sbUnderline != 0 }
-func (s style) strike() bool    { return s&sbStrike != 0 }
-func (s style) blink() bool     { return s&sbBlink != 0 }
-func (s style) element() bool   { return s&sbElement != 0 }
-func (s style) hyperlink() bool { return s&sbHyperlink != 0 }
+func (s style) fgColor() uint32  { return uint32(s & 0x0000_00ff_ffff) }
+func (s style) fgColorType() uint8  { return uint8((s&sbFGColorX) >> 48) }
+func (s style) bgColor() uint32  { return uint32((s & 0xffff_ff00_0000) >> 24) }
+func (s style) bgColorType() uint8  { return uint8((s&sbBGColorX) >> 51) }
+func (s style) bold() bool       { return s&sbBold != 0 }
+func (s style) faint() bool      { return s&sbFaint != 0 }
+func (s style) italic() bool     { return s&sbItalic != 0 }
+func (s style) underline() bool  { return s&sbUnderline != 0 }
+func (s style) strike() bool     { return s&sbStrike != 0 }
+func (s style) blink() bool      { return s&sbBlink != 0 }
+func (s style) element() bool    { return s&sbElement != 0 }
+func (s style) hyperlink() bool  { return s&sbHyperlink != 0 }
 
-func (s *style) setFGColor(v uint8)  { *s = (*s &^ 0xff) | style(v) }
-func (s *style) setBGColor(v uint8)  { *s = (*s &^ 0xff_00) | (style(v) << 8) }
-func (s *style) setFGColorX(v bool)  { *s = (*s &^ sbFGColorX) | booln(v, sbFGColorX) }
-func (s *style) setBGColorX(v bool)  { *s = (*s &^ sbBGColorX) | booln(v, sbBGColorX) }
+func (s *style) setFGColorDefault()  { *s = (*s &^ 0x7_0000_00ff_ffff) | (style(colorDefault) << 48) }
+func (s *style) setFGColorSGR(v uint8)  { *s = (*s &^ 0x7_0000_00ff_ffff) | style(v) | (style(colorSGR) << 48) }
+func (s *style) setFGColor8Bit(v uint8)  { *s = (*s &^ 0x7_0000_00ff_ffff) | style(v) | (style(color8Bit) << 48) }
+func (s *style) setFGColor24Bit(rgb [3]uint8)  { *s = (*s &^ 0x7_0000_00ff_ffff) | (style(rgb[0]) << 16) | (style(rgb[1]) << 8) | style(rgb[2]) | (style(color24Bit) << 48) }
+
+func (s *style) setBGColorDefault()  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(colorDefault) << 51) }
+func (s *style) setBGColorSGR(v uint8)  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(v) << 24) | (style(colorSGR) << 51) }
+func (s *style) setBGColor8Bit(v uint8)  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(v) << 24) | (style(color8Bit) << 51) }
+func (s *style) setBGColor24Bit(rgb [3]uint8)  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(rgb[0]) << 40) | (style(rgb[1]) << 32) | (style(rgb[2]) << 24) | (style(color24Bit) << 51) }
+
 func (s *style) setBold(v bool)      { *s = (*s &^ sbBold) | booln(v, sbBold) }
 func (s *style) setFaint(v bool)     { *s = (*s &^ sbFaint) | booln(v, sbFaint) }
 func (s *style) setItalic(v bool)    { *s = (*s &^ sbItalic) | booln(v, sbItalic) }
@@ -56,37 +80,53 @@ func (s *style) setElement(v bool)   { *s = (*s &^ sbElement) | booln(v, sbEleme
 func (s *style) setHyperlink(v bool) { *s = (*s &^ sbHyperlink) | booln(v, sbHyperlink) }
 
 const (
-	COLOR_NORMAL        = iota
-	COLOR_GOT_38_NEED_5 = iota
-	COLOR_GOT_48_NEED_5 = iota
-	COLOR_GOT_38        = iota
-	COLOR_GOT_48        = iota
+	COLOR_NORMAL   = iota
+	COLOR_GOT_38_2 = iota
+	COLOR_GOT_38_5 = iota
+	COLOR_GOT_48_2 = iota
+	COLOR_GOT_48_5 = iota
+	COLOR_GOT_38   = iota
+	COLOR_GOT_48   = iota
 )
 
 // CSS classes that make up the style
 func (s style) asClasses() []string {
 	var styles []string
 
-	if s.fgColor() > 0 && s.fgColor() < 38 && !s.fgColorX() {
-		styles = append(styles, "term-fg"+strconv.Itoa(int(s.fgColor())))
-	}
-	if s.fgColor() > 38 && !s.fgColorX() {
-		styles = append(styles, "term-fgi"+strconv.Itoa(int(s.fgColor())))
-
-	}
-	if s.fgColorX() {
+	switch s.fgColorType() {
+	case colorDefault:
+		// This should reset the color to default, but the previous behavior was to ignore it,
+		// so we'll do that.
+	case colorSGR:
+		if s.fgColor() > 29 && s.fgColor() < 38 {
+			styles = append(styles, "term-fg"+strconv.Itoa(int(s.fgColor())))
+		}
+		if s.fgColor() > 89 && s.fgColor() < 98 {
+			styles = append(styles, "term-fgi"+strconv.Itoa(int(s.fgColor())))
+		}
+	case color8Bit:
 		styles = append(styles, "term-fgx"+strconv.Itoa(int(s.fgColor())))
-
+	case color24Bit:
+		// This should set the fg color to the specified color, but the previous behavior was
+		// undefined and implementing that is outside the scope of this PR.
 	}
 
-	if s.bgColor() > 0 && s.bgColor() < 48 && !s.bgColorX() {
-		styles = append(styles, "term-bg"+strconv.Itoa(int(s.bgColor())))
-	}
-	if s.bgColor() > 48 && !s.bgColorX() {
-		styles = append(styles, "term-bgi"+strconv.Itoa(int(s.bgColor())))
-	}
-	if s.bgColorX() {
+	switch s.bgColorType() {
+	case colorDefault:
+		// This should reset the color to default, but the previous behavior was to ignore it,
+		// so we'll do that.
+	case colorSGR:
+		if s.bgColor() > 39 && s.bgColor() < 48 {
+			styles = append(styles, "term-bg"+strconv.Itoa(int(s.bgColor())))
+		}
+		if s.bgColor() > 99 && s.bgColor() < 108 {
+			styles = append(styles, "term-bgi"+strconv.Itoa(int(s.bgColor())))
+		}
+	case color8Bit:
 		styles = append(styles, "term-bgx"+strconv.Itoa(int(s.bgColor())))
+	case color24Bit:
+		// This should set the bg color to the specified color, but the previous behavior was
+		// undefined and implementing that is outside the scope of this PR.
 	}
 
 	if s.bold() {
@@ -119,6 +159,8 @@ func (s style) color(colors []string) style {
 	}
 
 	colorMode := COLOR_NORMAL
+	var rgb [3]uint8
+	var rgb_index uint8
 
 	for _, ccs := range colors {
 		// If multiple colors are defined, i.e. \e[30;42m\e then loop through each
@@ -130,29 +172,53 @@ func (s style) color(colors []string) style {
 
 		// State machine for XTerm colors, eg 38;5;150
 		switch colorMode {
-		case COLOR_GOT_38_NEED_5:
-			if cc == 5 {
-				colorMode = COLOR_GOT_38
-			} else {
-				colorMode = COLOR_NORMAL
-			}
-			continue
-		case COLOR_GOT_48_NEED_5:
-			if cc == 5 {
-				colorMode = COLOR_GOT_48
-			} else {
-				colorMode = COLOR_NORMAL
-			}
-			continue
 		case COLOR_GOT_38:
-			s.setFGColor(uint8(cc))
-			s.setFGColorX(true)
-			colorMode = COLOR_NORMAL
+			switch cc {
+			case 5:
+				colorMode = COLOR_GOT_38_5
+			case 2:
+				colorMode = COLOR_GOT_38_2
+				rgb_index = 0
+			default:
+				colorMode = COLOR_NORMAL
+			}
 			continue
 		case COLOR_GOT_48:
-			s.setBGColor(uint8(cc))
-			s.setBGColorX(true)
+			switch cc {
+			case 5:
+				colorMode = COLOR_GOT_38_5
+			case 2:
+				colorMode = COLOR_GOT_38_2
+				rgb_index = 0
+			default:
+				colorMode = COLOR_NORMAL
+			}
+			continue
+		case COLOR_GOT_38_5:
+			s.setFGColor8Bit(uint8(cc))
 			colorMode = COLOR_NORMAL
+			continue
+		case COLOR_GOT_48_5:
+			s.setBGColor8Bit(uint8(cc))
+			colorMode = COLOR_NORMAL
+			continue
+		case COLOR_GOT_38_2:
+			rgb[rgb_index] = uint8(cc)
+			if rgb_index == 3 {
+				s.setFGColor24Bit(rgb)
+				colorMode = COLOR_NORMAL
+				continue
+			}
+			rgb_index++
+			continue
+		case COLOR_GOT_48_2:
+			rgb[rgb_index] = uint8(cc)
+			if rgb_index == 3 {
+				s.setBGColor24Bit(rgb)
+				colorMode = COLOR_NORMAL
+				continue
+			}
+			rgb_index++
 			continue
 		}
 
@@ -186,21 +252,17 @@ func (s style) color(colors []string) style {
 		case 29:
 			s.setStrike(false)
 		case 38:
-			colorMode = COLOR_GOT_38_NEED_5
+			colorMode = COLOR_GOT_38
 		case 39:
-			s.setFGColor(0)
-			s.setFGColorX(false)
+			s.setFGColorDefault()
 		case 48:
-			colorMode = COLOR_GOT_48_NEED_5
+			colorMode = COLOR_GOT_48
 		case 49:
-			s.setBGColor(0)
-			s.setBGColorX(false)
+			s.setBGColorDefault()
 		case 30, 31, 32, 33, 34, 35, 36, 37, 90, 91, 92, 93, 94, 95, 96, 97:
-			s.setFGColor(uint8(cc))
-			s.setFGColorX(false)
+			s.setFGColorSGR(uint8(cc))
 		case 40, 41, 42, 43, 44, 45, 46, 47, 100, 101, 102, 103, 104, 105, 106, 107:
-			s.setBGColor(uint8(cc))
-			s.setBGColorX(false)
+			s.setBGColorSGR(uint8(cc))
 		}
 	}
 	return s

--- a/style.go
+++ b/style.go
@@ -5,17 +5,15 @@ import "strconv"
 type style uint64
 
 // style encoding:
-// 0... ...23  24... ...47  48...59     60     61   62....63
+// 0... ...23  24... ...47  48...57     58     59   60....63
 // [fg color]  [bg color]   [flags]  element  link  [unused]
 // flags = bold, faint, etc
 
 const (
 	sbFGColorX1 = style(1) << (48 + iota)
 	sbFGColorX2
-	sbFGColorX3
 	sbBGColorX1
 	sbBGColorX2
-	sbBGColorX3
 	sbBold
 	sbFaint
 	sbItalic
@@ -27,13 +25,12 @@ const (
 )
 
 const (
-	sbFGColorX = sbFGColorX1 | sbFGColorX2 | sbFGColorX3
-	sbBGColorX = sbBGColorX1 | sbBGColorX2 | sbBGColorX3
+	sbFGColorX = sbFGColorX1 | sbFGColorX2
+	sbBGColorX = sbBGColorX1 | sbBGColorX2
 )
 
 const (
 	colorNone = uint8(iota)
-	colorDefault
 	colorSGR
 	color8Bit
 	color24Bit
@@ -41,7 +38,7 @@ const (
 
 
 // Used for comparing styles - ignores the element bit, link bit, and unused bits.
-const styleComparisonMask = 0x0fff_ffff_ffff_ffff
+const styleComparisonMask = 0x03ff_ffff_ffff_ffff
 
 // isPlain reports if there is no style information. elements (that have no
 // other style set) are also considered plain.
@@ -50,7 +47,7 @@ func (s style) isPlain() bool { return s&styleComparisonMask == 0 }
 func (s style) fgColor() uint32  { return uint32(s & 0x0000_00ff_ffff) }
 func (s style) fgColorType() uint8  { return uint8((s&sbFGColorX) >> 48) }
 func (s style) bgColor() uint32  { return uint32((s & 0xffff_ff00_0000) >> 24) }
-func (s style) bgColorType() uint8  { return uint8((s&sbBGColorX) >> 51) }
+func (s style) bgColorType() uint8  { return uint8((s&sbBGColorX) >> 50) }
 func (s style) bold() bool       { return s&sbBold != 0 }
 func (s style) faint() bool      { return s&sbFaint != 0 }
 func (s style) italic() bool     { return s&sbItalic != 0 }
@@ -60,15 +57,15 @@ func (s style) blink() bool      { return s&sbBlink != 0 }
 func (s style) element() bool    { return s&sbElement != 0 }
 func (s style) hyperlink() bool  { return s&sbHyperlink != 0 }
 
-func (s *style) setFGColorDefault()  { *s = (*s &^ 0x7_0000_00ff_ffff) | (style(colorDefault) << 48) }
-func (s *style) setFGColorSGR(v uint8)  { *s = (*s &^ 0x7_0000_00ff_ffff) | style(v) | (style(colorSGR) << 48) }
-func (s *style) setFGColor8Bit(v uint8)  { *s = (*s &^ 0x7_0000_00ff_ffff) | style(v) | (style(color8Bit) << 48) }
-func (s *style) setFGColor24Bit(rgb [3]uint8)  { *s = (*s &^ 0x7_0000_00ff_ffff) | (style(rgb[0]) << 16) | (style(rgb[1]) << 8) | style(rgb[2]) | (style(color24Bit) << 48) }
+func (s *style) resetFGColor()  { *s = (*s &^ 0x3_0000_00ff_ffff) }
+func (s *style) setFGColorSGR(v uint8)  { *s = (*s &^ 0x3_0000_00ff_ffff) | style(v) | (style(colorSGR) << 48) }
+func (s *style) setFGColor8Bit(v uint8)  { *s = (*s &^ 0x3_0000_00ff_ffff) | style(v) | (style(color8Bit) << 48) }
+func (s *style) setFGColor24Bit(rgb [3]uint8)  { *s = (*s &^ 0x3_0000_00ff_ffff) | (style(rgb[0]) << 16) | (style(rgb[1]) << 8) | style(rgb[2]) | (style(color24Bit) << 48) }
 
-func (s *style) setBGColorDefault()  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(colorDefault) << 51) }
-func (s *style) setBGColorSGR(v uint8)  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(v) << 24) | (style(colorSGR) << 51) }
-func (s *style) setBGColor8Bit(v uint8)  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(v) << 24) | (style(color8Bit) << 51) }
-func (s *style) setBGColor24Bit(rgb [3]uint8)  { *s = (*s &^ 0x38_ffff_ff00_0000) | (style(rgb[0]) << 40) | (style(rgb[1]) << 32) | (style(rgb[2]) << 24) | (style(color24Bit) << 51) }
+func (s *style) resetBGColor()  { *s = (*s &^ 0xc_ffff_ff00_0000) }
+func (s *style) setBGColorSGR(v uint8)  { *s = (*s &^ 0xc_ffff_ff00_0000) | (style(v) << 24) | (style(colorSGR) << 50) }
+func (s *style) setBGColor8Bit(v uint8)  { *s = (*s &^ 0xc_ffff_ff00_0000) | (style(v) << 24) | (style(color8Bit) << 50) }
+func (s *style) setBGColor24Bit(rgb [3]uint8)  { *s = (*s &^ 0xc_ffff_ff00_0000) | (style(rgb[0]) << 40) | (style(rgb[1]) << 32) | (style(rgb[2]) << 24) | (style(color24Bit) << 50) }
 
 func (s *style) setBold(v bool)      { *s = (*s &^ sbBold) | booln(v, sbBold) }
 func (s *style) setFaint(v bool)     { *s = (*s &^ sbFaint) | booln(v, sbFaint) }
@@ -94,9 +91,6 @@ func (s style) asClasses() []string {
 	var styles []string
 
 	switch s.fgColorType() {
-	case colorDefault:
-		// This should reset the color to default, but the previous behavior was to ignore it,
-		// so we'll do that.
 	case colorSGR:
 		if s.fgColor() > 29 && s.fgColor() < 38 {
 			styles = append(styles, "term-fg"+strconv.Itoa(int(s.fgColor())))
@@ -112,9 +106,6 @@ func (s style) asClasses() []string {
 	}
 
 	switch s.bgColorType() {
-	case colorDefault:
-		// This should reset the color to default, but the previous behavior was to ignore it,
-		// so we'll do that.
 	case colorSGR:
 		if s.bgColor() > 39 && s.bgColor() < 48 {
 			styles = append(styles, "term-bg"+strconv.Itoa(int(s.bgColor())))
@@ -186,9 +177,9 @@ func (s style) color(colors []string) style {
 		case COLOR_GOT_48:
 			switch cc {
 			case 5:
-				colorMode = COLOR_GOT_38_5
+				colorMode = COLOR_GOT_48_5
 			case 2:
-				colorMode = COLOR_GOT_38_2
+				colorMode = COLOR_GOT_48_2
 				rgb_index = 0
 			default:
 				colorMode = COLOR_NORMAL
@@ -254,11 +245,11 @@ func (s style) color(colors []string) style {
 		case 38:
 			colorMode = COLOR_GOT_38
 		case 39:
-			s.setFGColorDefault()
+			s.resetFGColor()
 		case 48:
 			colorMode = COLOR_GOT_48
 		case 49:
-			s.setBGColorDefault()
+			s.resetBGColor()
 		case 30, 31, 32, 33, 34, 35, 36, 37, 90, 91, 92, 93, 94, 95, 96, 97:
 			s.setFGColorSGR(uint8(cc))
 		case 40, 41, 42, 43, 44, 45, 46, 47, 100, 101, 102, 103, 104, 105, 106, 107:

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -258,6 +258,11 @@ var rendererTestCases = []struct {
 		want:  "<span class=\"term-fgx169 term-bgx50\">hello</span> <span class=\"term-fgx179\">goodbye</span>",
 	},
 	{
+		name:  "doesn't trip over 24-bit colors",
+		input: "\x1b[48;5;50;38;2;48;7;1mhello\x1b[0m \x1b[38;5;179;48;2;38;5;200mgoodbye",
+		want:  "<span class=\"term-bgx50\">hello</span> <span class=\"term-fgx179\">goodbye</span>",
+	},
+	{
 		name:  "handles non-xterm codes on the same line as xterm colors",
 		input: "\x1b[38;5;228;5;1mblinking and bold\x1b",
 		want:  `<span class="term-fgx228 term-fg1 term-fg5">blinking and bold</span>`,


### PR DESCRIPTION
This adds the parsing logic, but does not render, 24 bit colors specified by ANSI as described here: https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit

I need the parser to work for my own inscrutable purposes, but I don't need the renderer, so implementing support for it seemed outside of my scope. Even though the 24-bit colors are not rendered, it is worth noting that they never were, and this at least allows the parser to continue parsing colors it _can_ recognize if it hits a 24-bit color, whereas before it would have parsed the RGB values as SGR values, effectively interpreting noise as formatting instructions.

