### PR TITLE
Fix two closely related scrollout bugs

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -237,6 +237,11 @@ func (s *Screen) currentLineForWriting() *screenLine {
 			// the "visible screen". We're talking a line that's 160*200
 			// chars long for the top of the screen to be reached that way.)
 			scrollOutTo = s.top()
+			if s.top() == 0 {
+				// We still need to scroll out a line, even if there are no lines above
+				// the top of the window. Get the next line.
+				scrollOutTo = len(s.screen)
+			}
 			for i, l := range s.screen[:scrollOutTo] {
 				if l.newline {
 					scrollOutTo = i + 1
@@ -250,14 +255,21 @@ func (s *Screen) currentLineForWriting() *screenLine {
 		}
 		s.LinesScrolledOut += scrollOutTo
 
-		// Make a new line on the bottom using a recycled node slice. There's
-		// at least one we just added.
-		r1 := len(s.nodeRecycling) - 1
+		var nodes []node
+		if r1 := len(s.nodeRecycling) - 1; r1 >= 0 {
+			// Make a new line on the bottom using a recycled node slice. There's
+			// usually at least one we just added.
+			nodes = s.nodeRecycling[r1]
+			s.nodeRecycling = s.nodeRecycling[:r1]
+		} else {
+			// No nodes to recycle, make a new node slice. This happens when we scroll
+			// out a line that consisted of no screenlines.
+			nodes = make([]node, 0)
+		}
 		newLine := screenLine{
-			nodes:   s.nodeRecycling[r1],
+			nodes:   nodes,
 			newline: true,
 		}
-		s.nodeRecycling = s.nodeRecycling[:r1]
 		s.screen = append(s.screen[scrollOutTo:], newLine)
 
 		// Since the buffer added 1 line, s.y moves upwards.

--- a/screen.go
+++ b/screen.go
@@ -264,7 +264,7 @@ func (s *Screen) currentLineForWriting() *screenLine {
 		} else {
 			// No nodes to recycle, make a new node slice. This happens when we scroll
 			// out a line that consisted of no screenlines.
-			nodes = make([]node, 0)
+			nodes = make([]node, 0, s.cols)
 		}
 		newLine := screenLine{
 			nodes:   nodes,

--- a/screen_test.go
+++ b/screen_test.go
@@ -34,22 +34,20 @@ var currentLineForWritingTestCases = []struct {
 
 func TestCurrentLineForWriting(t *testing.T) {
 	for _, test := range currentLineForWritingTestCases {
-		s, err := NewScreen(WithMaxSize(0, test.maxlines))
-		got := []string{}
-		s.ScrollOutFunc = func(line string) { got = append(got, line) }
-		_ = s.currentLineForWriting()
-		s.Write([]byte(test.input))
-		if err != nil {
-			t.Errorf("Failure for '%s':\nNewScreen returned an error: %s", test.name, err)
-		}
-		_ = s.currentLineForWriting()
+		t.Run(test.name, func(t *testing.T) {
+			s, err := NewScreen(WithMaxSize(0, test.maxlines))
+			if err != nil {
+				t.Fatalf("NewScreen(WithMaxSize(0, %d)) error: %s", test.maxlines, err)
+			}
+			got := []string{}
+			s.ScrollOutFunc = func(line string) { got = append(got, line) }
+			_ = s.currentLineForWriting()
+			s.Write([]byte(test.input))
+			_ = s.currentLineForWriting()
 
-		if diff := cmp.Diff(got, test.want); diff != "" {
-			t.Errorf(
-				"Failure for '%s':\nscrolledOutFunc sequence of parameters diff (-got +want):\n%s",
-				test.name,
-				diff,
-			)
-		}
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("scrolledOutFunc sequence of parameters diff (-got +want):\n%s", diff)
+			}
+		})
 	}
 }

--- a/screen_test.go
+++ b/screen_test.go
@@ -1,0 +1,55 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var currentLineForWritingTestCases = []struct {
+	name     string
+	input    string
+	want     []string
+	maxlines int
+}{
+	{
+		name: "Test no index out of range panic",
+		input: "\n",
+		want: []string{"&nbsp;\n"},
+		maxlines: 1,
+	},
+	{
+		name: "Test scroll out first line",
+		input: "a\n",
+		want: []string{"a\n"},
+		maxlines: 1,
+	},
+	{
+		name: "Test scroll out several lines",
+		input: "a\nb\nc\nd",
+		want: []string{"a\n", "b\n"},
+		maxlines: 2,
+	},
+}
+
+func TestCurrentLineForWriting(t *testing.T) {
+	for _, test := range currentLineForWritingTestCases {
+		s, err := NewScreen(WithMaxSize(0, test.maxlines))
+		got := []string{}
+		s.ScrollOutFunc = func(line string) { got = append(got, line) }
+		_ = s.currentLineForWriting()
+		s.Write([]byte(test.input))
+		if err != nil {
+			t.Errorf("Failure for '%s':\nNewScreen returned an error: %s", test.name, err)
+		}
+		_ = s.currentLineForWriting()
+
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Errorf(
+				"Failure for '%s':\nscrolledOutFunc sequence of parameters diff (-got +want):\n%s",
+				test.name,
+				diff,
+			)
+		}
+	}
+}


### PR DESCRIPTION
When using the library, I ran into two bugs when using the `ScrollOutFunc` callback. The first is that if a new line is created when no lines have been scrolled out, the attempt to recycle nodes will cause an `index out of range` panic. The second is that if a line is scrolled out with no terminating new line, the line does not actually get scrolled out and instead an errant new line is printed.

Included is a fix for both of these bugs, as well as a test demonstrating them. 