### PR TITLE
Do line wrapping in one place on-demand

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -192,6 +192,22 @@ func (s *Screen) currentLine() *screenLine {
 // line allocated in the buffer yet, allocates a new line and ensures it has
 // enough nodes to write something at the cursor position.
 func (s *Screen) currentLineForWriting() *screenLine {
+	// If the cursor is past the end, we actually need the line after this one.
+	if s.x == s.cols {
+		// Handle line wrapping.
+		// Doing this at write time allows the cursor to be positioned past the end,
+		// as would happen if the entire line (including the last column) was
+		// written to, but doesn't allow writing past the last column.
+		// Since the cursor cannot be moved to s.cols, this can only happen if we
+		// have written all the way to the end of a line, so we can safely assume
+		// the current line exists.
+
+		// This, and the final line, are the only instances in which newline should
+		// be false.
+		s.currentLine().newline = false
+		s.x = 0
+		s.y++
+	}
 	// Ensure there are enough lines on screen to start writing here.
 	for s.currentLine() == nil {
 		// If maxLines is not in use, or adding a new line would not make it
@@ -281,19 +297,6 @@ func (s *Screen) currentLineForWriting() *screenLine {
 
 // Write a character to the screen's current X&Y, along with the current screen style
 func (s *Screen) write(data rune) {
-	// Handle line wrapping
-	// Doing this at write time allows the cursor to be positioned past the end,
-	// as would happen if the entire line (including the last column) was
-	// written to, but doesn't allow writing past the last column.
-	if s.x >= s.cols {
-		// Don't actually wrap the line when outputting to plain text or HTML.
-		if line := s.currentLine(); line != nil {
-			line.newline = false
-		}
-		s.x = 0
-		s.y++
-	}
-
 	line := s.currentLineForWriting()
 	line.writeNode(s.x, node{blob: data, style: s.style})
 
@@ -321,15 +324,6 @@ func (s *Screen) appendMany(data []rune) {
 }
 
 func (s *Screen) appendElement(i *element) {
-	// Handle wrapping. See comment in [write].
-	if s.x >= s.cols {
-		if line := s.currentLine(); line != nil {
-			line.newline = false
-		}
-		s.x = 0
-		s.y++
-	}
-
 	line := s.currentLineForWriting()
 	idx := len(line.elements)
 	line.elements = append(line.elements, i)
@@ -555,13 +549,16 @@ func (s *Screen) AsPlainText() string {
 }
 
 func (s *Screen) newLine() {
+	// Do the carriage return first to ensure that currentLineForWriting can't
+	// give us the next line if the cursor was placed past the end of the line.
+	s.x = 0
+
 	// Ensure the previous line, if it already exists, gets a \n in the render.
 	// This could happen if we got CSI A (cursor up), and then \n onto a line
 	// that had previously been wrapped from the previous line.
 	if line := s.currentLine(); line != nil {
 		line.newline = true
 	}
-	s.x = 0
 	s.y++
 }
 


### PR DESCRIPTION
This makes a follow-up PR that improves handling of new lines simpler, as well as reducing code duplication.