### PR TITLE
Bump version.go for v3.17.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.16.8"
+var baseVersion string = "3.17.0"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.17.0](https://github.com/buildkite/terminal-to-html/tree/v3.17.0) (2026-06-28)
[Full Changelog](https://github.com/buildkite/terminal-to-html/compare/v3.16.8...v3.17.0)

### Added
- Handle parsing 24 bit colors [#224](https://github.com/buildkite/terminal-to-html/pull/224) (@tempoz)
- Add a raw text output format [#258](https://github.com/buildkite/terminal-to-html/pull/258) (@omehegan)

### Changed
- Strip binaries [#256](https://github.com/buildkite/terminal-to-html/pull/256) (@DrJosh9000)
- Do line wrapping in one place on-demand [#238](https://github.com/buildkite/terminal-to-html/pull/238) (@tempoz)

### Fixed 
- Fix cursor past the end bug [#237](https://github.com/buildkite/terminal-to-html/pull/237) (@tempoz)
- Fix two closely related scrollout bugs [#227](https://github.com/buildkite/terminal-to-html/pull/227) (@tempoz)

### Dependency updates
- Bump docker/library/golang from 1.26.3 to 1.26.4 [#274](https://github.com/buildkite/terminal-to-html/pull/274) (@dependabot[bot])
- Bump golang.org/x/sys from 0.45.0 to 0.46.0 [#275](https://github.com/buildkite/terminal-to-html/pull/275) (@dependabot[bot])
- Bump docker/library/golang from `313faae` to `2d6c802` [#273](https://github.com/buildkite/terminal-to-html/pull/273) (@dependabot[bot])
- Bump golang.org/x/sys from 0.42.0 to 0.45.0 [#272](https://github.com/buildkite/terminal-to-html/pull/272) (@dependabot[bot])
- Bump docker/library/golang from 1.26.1 to 1.26.3 [#271](https://github.com/buildkite/terminal-to-html/pull/271) (@dependabot[bot])
- Bump docker/library/golang from `c7e98cc` to `595c784` [#267](https://github.com/buildkite/terminal-to-html/pull/267) (@dependabot[bot])
- Bump golang.org/x/sys from 0.41.0 to 0.42.0 [#262](https://github.com/buildkite/terminal-to-html/pull/262) (@dependabot[bot])
- Bump docker/library/golang from 1.25.6 to 1.26.1 [#264](https://github.com/buildkite/terminal-to-html/pull/264) (@dependabot[bot])
- Bump golang.org/x/sys from 0.40.0 to 0.41.0 [#259](https://github.com/buildkite/terminal-to-html/pull/259) (@dependabot[bot])
- Bump golang.org/x/sys from 0.38.0 to 0.40.0 [#254](https://github.com/buildkite/terminal-to-html/pull/254) (@dependabot[bot])
- Bump docker/library/golang from 1.25.4 to 1.25.6 [#255](https://github.com/buildkite/terminal-to-html/pull/255) (@dependabot[bot])
- Bump docker/library/golang from `e68f6a0` to `6981837` [#251](https://github.com/buildkite/terminal-to-html/pull/251) (@dependabot[bot])
- Bump docker/library/golang from 1.25.3 to 1.25.4 [#250](https://github.com/buildkite/terminal-to-html/pull/250) (@dependabot[bot])
- Bump golang.org/x/sys from 0.35.0 to 0.38.0 [#249](https://github.com/buildkite/terminal-to-html/pull/249) (@dependabot[bot])
- Bump docker/library/golang from 1.25.0 to 1.25.3 [#248](https://github.com/buildkite/terminal-to-html/pull/248) (@dependabot[bot])
- Bump docker/library/golang from `91e2cd4` to `5502b0e` [#243](https://github.com/buildkite/terminal-to-html/pull/243) (@dependabot[bot])
- Bump docker/library/golang from 1.24.6 to 1.25.0 [#242](https://github.com/buildkite/terminal-to-html/pull/242) (@dependabot[bot])
- Bump docker/library/golang from 1.24.4 to 1.24.6 [#240](https://github.com/buildkite/terminal-to-html/pull/240) (@dependabot[bot])
- Bump golang.org/x/sys from 0.34.0 to 0.35.0 [#239](https://github.com/buildkite/terminal-to-html/pull/239) (@dependabot[bot])
- Bump golang.org/x/sys from 0.33.0 to 0.34.0 [#235](https://github.com/buildkite/terminal-to-html/pull/235) (@dependabot[bot])
- Bump github.com/urfave/cli/v2 from 2.27.6 to 2.27.7 [#234](https://github.com/buildkite/terminal-to-html/pull/234) (@dependabot[bot])
- Bump docker/library/golang from 1.24.3 to 1.24.4 [#232](https://github.com/buildkite/terminal-to-html/pull/232) (@dependabot[bot])
- Bump docker/library/golang from `39d9e7d` to `86b4cff` [#230](https://github.com/buildkite/terminal-to-html/pull/230) (@dependabot[bot])
- Bump docker/library/golang from 1.24.1 to 1.24.3 [#229](https://github.com/buildkite/terminal-to-html/pull/229) (@dependabot[bot])
- Bump golang.org/x/sys from 0.32.0 to 0.33.0 [#228](https://github.com/buildkite/terminal-to-html/pull/228) (@dependabot[bot])
- Bump golang.org/x/sys from 0.31.0 to 0.32.0 [#226](https://github.com/buildkite/terminal-to-html/pull/226) (@dependabot[bot])