### PR TITLE
[A-1488] Fix panic when parsing 24-bit colour sequences

### DIFF
--- a/style.go
+++ b/style.go
@@ -195,7 +195,7 @@ func (s style) color(colors []string) style {
 			continue
 		case COLOR_GOT_38_2:
 			rgb[rgb_index] = uint8(cc)
-			if rgb_index == 3 {
+			if rgb_index == 2 {
 				s.setFGColor24Bit(rgb)
 				colorMode = COLOR_NORMAL
 				continue
@@ -204,7 +204,7 @@ func (s style) color(colors []string) style {
 			continue
 		case COLOR_GOT_48_2:
 			rgb[rgb_index] = uint8(cc)
-			if rgb_index == 3 {
+			if rgb_index == 2 {
 				s.setBGColor24Bit(rgb)
 				colorMode = COLOR_NORMAL
 				continue

--- a/style_test.go
+++ b/style_test.go
@@ -1,0 +1,33 @@
+package terminal
+
+import "testing"
+
+// There's a bit of trickery involved in parsing 24-bit color
+// sequences that caused them to be silently ignored in the
+// past. These tests assert that they are actually applied.
+func TestColor24BitIsApplied(t *testing.T) {
+	const (
+		r, g, b = 100, 150, 200
+		wantRGB = uint32(r<<16 | g<<8 | b) // 0x6496C8
+	)
+
+	t.Run("foreground", func(t *testing.T) {
+		s := style(0).color([]string{"38", "2", "100", "150", "200"})
+		if got := s.fgColorType(); got != color24Bit {
+			t.Errorf("fgColorType() = %d, want %d (color24Bit)", got, color24Bit)
+		}
+		if got := s.fgColor(); got != wantRGB {
+			t.Errorf("fgColor() = %#06x, want %#06x", got, wantRGB)
+		}
+	})
+
+	t.Run("background", func(t *testing.T) {
+		s := style(0).color([]string{"48", "2", "100", "150", "200"})
+		if got := s.bgColorType(); got != color24Bit {
+			t.Errorf("bgColorType() = %d, want %d (color24Bit)", got, color24Bit)
+		}
+		if got := s.bgColor(); got != wantRGB {
+			t.Errorf("bgColor() = %#06x, want %#06x", got, wantRGB)
+		}
+	})
+}

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -263,6 +263,11 @@ var rendererTestCases = []struct {
 		want:  "<span class=\"term-bgx50\">hello</span> <span class=\"term-fgx179\">goodbye</span>",
 	},
 	{
+		name:  "doesn't panic on 24-bit colors with extra trailing values",
+		input: "\x1b[38;2;100;150;200;250;255mhello\x1b[0m",
+		want:  `<span class="">hello</span>`,
+	},
+	{
 		name:  "handles non-xterm codes on the same line as xterm colors",
 		input: "\x1b[38;5;228;5;1mblinking and bold\x1b",
 		want:  `<span class="term-fgx228 term-fg1 term-fg5">blinking and bold</span>`,


### PR DESCRIPTION
Fix `panic: runtime error: index out of range [3] with length 3` crash when parsing certain colour sequences.

## Cause

The RGB parser writes each component into a `[3]uint8` array and only checks for completion after the write, but it is using the wrong index.

```go
rgb[rgb_index] = uint8(cc)
if rgb_index == 3 { ... }   // valid indices are 0,1,2
```

For a sequence like `\e[38;2;R;G;B...,` `rgb_index` advances 0→1→2→3 as R, G, B are consumed. The completion branch (`== 3`) never fires for a well-formed 3-value colour, so the parser stays in colour mode. If a 4th value follows, `rgb[3] = ...` writes out of bounds and panics.

This also means valid 24-bit colours have never actually applied.

## Fix

Complete the colour once the third component (`rgb_index == 2`) is written.

```go
rgb[rgb_index] = uint8(cc)
if rgb_index == 2 { ... }
```