### PR TITLE
[A-1488] Bump version.go for v3.17.1

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package terminal
 
-var baseVersion string = "3.17.0"
+var baseVersion string = "3.17.1"
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
Bumping version for a patch release to fix `index out or range` panic bug in RGB parser.

## What's Changed
* Bump docker/library/golang from `792443b` to `f96cc55` by @dependabot[bot] in https://github.com/buildkite/terminal-to-html/pull/277
* [A-1488] Fix panic when parsing 24-bit colour sequences by @isaacsu in https://github.com/buildkite/terminal-to-html/pull/278

**Full Changelog**: https://github.com/buildkite/terminal-to-html/compare/v3.17.0...v3.17.1