### PR TITLE
Drop `html/template` from the rendering path

### DIFF
--- a/output.go
+++ b/output.go
@@ -2,7 +2,6 @@ package terminal
 
 import (
 	"html"
-	"html/template"
 	"maps"
 	"slices"
 	"strconv"
@@ -10,22 +9,16 @@ import (
 	"time"
 )
 
-var (
-	timeTagImpl = template.Must(template.New("time").Parse(
-		`<time datetime="{{.}}">{{.}}</time>`,
-	))
-
-	openSpanTagTmpl = template.Must(template.New("span").Parse(
-		`<span class="{{.}}">`,
-	))
-)
-
 type outputBuffer struct {
 	strings.Builder
 }
 
 func (b *outputBuffer) appendNodeStyle(n node) {
-	openSpanTagTmpl.Execute(b, strings.Join(n.style.asClasses(), " "))
+	// asClasses only ever emits "term-" + prefix + strconv.Itoa(int), so
+	// the joined value is always [a-z0-9- ] — nothing to escape.
+	b.WriteString(`<span class="`)
+	b.WriteString(strings.Join(n.style.asClasses(), " "))
+	b.WriteString(`">`)
 }
 
 func (b *outputBuffer) closeStyle() {
@@ -54,7 +47,12 @@ func (b *outputBuffer) appendMeta(namespace string, data map[string]string) {
 	time := time.Unix(millis/1000, (millis%1000)*1_000_000).UTC()
 	// One of the formats accepted by the <time> tag:
 	datetime := time.Format("2006-01-02T15:04:05.999Z")
-	timeTagImpl.Execute(b, datetime)
+	// A formatted timestamp is always [0-9-T:.Z] — nothing to escape.
+	b.WriteString(`<time datetime="`)
+	b.WriteString(datetime)
+	b.WriteString(`">`)
+	b.WriteString(datetime)
+	b.WriteString(`</time>`)
 }
 
 // Append a character to our outputbuffer, escaping HTML bits as necessary.

--- a/output_test.go
+++ b/output_test.go
@@ -45,3 +45,83 @@ func TestScreenLineAsHTML_Interleaving(t *testing.T) {
 		})
 	}
 }
+
+// The <time> and <span class> tags are written directly rather than through
+// html/template, on the proof that their interpolated values never contain
+// characters the template escaper would touch. These tests pin the exact
+// bytes of those tags, across every shape the values can take.
+
+func TestLineToHTML_TimeTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "millisecond fraction",
+			input: "\x1b_bk;t=123\x07x",
+			want:  `<time datetime="1970-01-01T00:00:00.123Z">1970-01-01T00:00:00.123Z</time>x` + "\n",
+		},
+		{
+			// The .999 format drops trailing zeros from the fraction.
+			name:  "fraction with trailing zero",
+			input: "\x1b_bk;t=120\x07x",
+			want:  `<time datetime="1970-01-01T00:00:00.12Z">1970-01-01T00:00:00.12Z</time>x` + "\n",
+		},
+		{
+			name:  "single-digit fraction",
+			input: "\x1b_bk;t=100\x07x",
+			want:  `<time datetime="1970-01-01T00:00:00.1Z">1970-01-01T00:00:00.1Z</time>x` + "\n",
+		},
+		{
+			// …and the dot itself when the fraction is zero.
+			name:  "whole second",
+			input: "\x1b_bk;t=1000\x07x",
+			want:  `<time datetime="1970-01-01T00:00:01Z">1970-01-01T00:00:01Z</time>x` + "\n",
+		},
+		{
+			name:  "modern date",
+			input: "\x1b_bk;t=1500000000123\x07x",
+			want:  `<time datetime="2017-07-14T02:40:00.123Z">2017-07-14T02:40:00.123Z</time>x` + "\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := NewScreen()
+			if err != nil {
+				t.Fatalf("NewScreen() = %v", err)
+			}
+			s.Write([]byte(test.input))
+			if len(s.screen) != 1 {
+				t.Fatalf("len(s.screen) = %d, want 1", len(s.screen))
+			}
+
+			got := lineToHTML(s.screen[:1], true)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("lineToHTML(s.screen[:1], true) diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLineToHTML_SpanClassJoin(t *testing.T) {
+	// Several styles at once, so the class attribute exercises the joined,
+	// multi-class form: fg and bg colors first, then attributes.
+	input := "\x1b[1;3;35;41mx"
+	want := `<span class="term-fg35 term-bg41 term-fg1 term-fg3">x</span>` + "\n"
+
+	s, err := NewScreen()
+	if err != nil {
+		t.Fatalf("NewScreen() = %v", err)
+	}
+	s.Write([]byte(input))
+	if len(s.screen) != 1 {
+		t.Fatalf("len(s.screen) = %d, want 1", len(s.screen))
+	}
+
+	got := lineToHTML(s.screen[:1], true)
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("lineToHTML(s.screen[:1], true) diff (-got +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
**Disclosure:** I haven't written much Go lately, and the bots helped me write this one. 

While experimenting with compiling this library to WASM with TinyGo for rendering logs in the browser, we found it compiles cleanly but traps on the first rendered line, with `unreachable` inside text/template.addValueFuncs. TinyGo can't support the reflection-based template engine, and it turns out html/template is only here for two single-placeholder templates: `<time datetime="{{.}}">{{.}}</time>` and `<span class="{{.}}">`.

Writing those tags directly is byte-for-byte identical for every possible input, because both interpolated values are machine-generated and provably contain nothing html/template's escaper would touch (its table covers NUL " & ' + < >):

  - the <time> value is time.Format("2006-01-02T15:04:05.999Z"), so it is always [0-9], '-', 'T', ':', '.', 'Z';
  - the class list is strings.Join(style.asClasses(), " "), and asClasses only ever emits "term-" plus a fixed prefix plus strconv.Itoa(int), so it is always [a-z0-9-] and spaces.

The new tests pin the exact tag bytes across the shapes those values take: the .999 fraction forms, including the dot disappearing on whole seconds, and the joined multi-class span. They pass identically against the html/template implementation, which makes the byte-parity claim checkable.

Also verified by rendering a 13MB real job log and a hostile-payload fixture through both the standard Go and TinyGo binaries and diffing the output.

Beyond unblocking TinyGo, this also shrinks the standard Go binary and takes reflection out of the per-line hot path.